### PR TITLE
marked the regioncode and storeid VO as final

### DIFF
--- a/src/Value/RegionCode.php
+++ b/src/Value/RegionCode.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ORM\Embeddable
  */
-class RegionCode
+final class RegionCode
 {
     /**
      * @ORM\Column(name="region_code", type="string", length=2)

--- a/src/Value/StoreId.php
+++ b/src/Value/StoreId.php
@@ -8,7 +8,7 @@ use MyOnlineStore\Common\Domain\Assertion\NumericAssertionTrait;
 /**
  * @ORM\Embeddable
  */
-class StoreId
+final class StoreId
 {
     use NumericAssertionTrait;
 


### PR DESCRIPTION
Reverts #1 and #2 which was required for backwards compatibility with our session backend. 