### PR TITLE
Method added to generic collection to allow equality check

### DIFF
--- a/src/Collection/ImmutableCollectionInterface.php
+++ b/src/Collection/ImmutableCollectionInterface.php
@@ -18,6 +18,15 @@ interface ImmutableCollectionInterface extends \Countable, \IteratorAggregate
     public function each(callable $callback);
 
     /**
+     * Returns if given collection is of the same type and has the same elements
+     *
+     * @param ImmutableCollectionInterface $otherCollection
+     *
+     * @return bool
+     */
+    public function equals(ImmutableCollectionInterface $otherCollection): bool;
+
+    /**
      * @return mixed
      */
     public function first();

--- a/src/Collection/MutableCollection.php
+++ b/src/Collection/MutableCollection.php
@@ -42,6 +42,28 @@ class MutableCollection extends \ArrayObject implements MutableCollectionInterfa
     /**
      * @inheritDoc
      */
+    public function equals(ImmutableCollectionInterface $otherCollection): bool
+    {
+        if (\get_class($this) !== \get_class($otherCollection)) {
+            return false;
+        }
+
+        if ($this->count() !== $otherCollection->count()) {
+            return false;
+        }
+
+        foreach ($this as $entry) {
+            if (!$otherCollection->contains($entry)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function first()
     {
         return reset($this);

--- a/tests/Collection/MutableCollectionTest.php
+++ b/tests/Collection/MutableCollectionTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Tests\Collection;
 
+use MyOnlineStore\Common\Domain\Collection\ImmutableCollection;
 use MyOnlineStore\Common\Domain\Collection\MutableCollection;
 
 final class MutableCollectionTest extends \PHPUnit\Framework\TestCase
@@ -69,6 +70,24 @@ final class MutableCollectionTest extends \PHPUnit\Framework\TestCase
                 $item->next();
             }
         );
+    }
+
+    public function testEqualsWillReturnTrueIfCollectionsAreOfTheSameTypeAndContainsTheSameElements()
+    {
+        $element1 = new \stdClass();
+        $element2 = new \stdClass();
+        $collection = new MutableCollection([$element1, $element2]);
+
+        self::assertTrue($collection->equals(new MutableCollection([$element1, $element2])));
+
+        // same elements in different order
+        self::assertTrue($collection->equals(new MutableCollection([$element2, $element1])));
+
+        // different collection type
+        self::assertFalse($collection->equals(new ImmutableCollection([$element1, $element2])));
+
+        // missing element 2
+        self::assertFalse($collection->equals(new MutableCollection([$element1])));
     }
 
     public function testFilterWillReturnCorrectElements()


### PR DESCRIPTION
Implementation based on mathematical set theory: collections are equal when they contain the same elements in any order.