### PR TITLE
\ArrayAccess is needed but not specified as extended interface

### DIFF
--- a/src/Collection/ImmutableCollectionInterface.php
+++ b/src/Collection/ImmutableCollectionInterface.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Collection;
 
-interface ImmutableCollectionInterface extends \Countable, \IteratorAggregate
+interface ImmutableCollectionInterface extends \Countable, \IteratorAggregate, \ArrayAccess
 {
     /**
      * @param mixed $element


### PR DESCRIPTION
This is incorrect but also causes issues when using a collection as a mock and trying to mock method `offsetGet`