### PR TITLE
Minor performance improvement for Locale::equals

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "require-dev": {
         "doctrine/orm": "^2.7",
         "myonlinestore/coding-standard": "^2.0",
+        "phpbench/phpbench": "^0.17.1",
         "phpunit/phpunit": "^8.5",
         "vimeo/psalm": "^3.11"
     },

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,0 +1,4 @@
+{
+    "bootstrap": "vendor/autoload.php",
+    "retry_threshold": 5
+}

--- a/src/Value/Locale.php
+++ b/src/Value/Locale.php
@@ -52,7 +52,8 @@ final class Locale
 
     public function equals(self $locale): bool
     {
-        return 0 === \strcmp((string) $this, (string) $locale);
+        return $this->regionCode->equals($locale->regionCode) &&
+            $this->languageCode->equals($locale->languageCode);
     }
 
     public function languageCode(): LanguageCode

--- a/tests/benchmarks/Value/LocaleBench.php
+++ b/tests/benchmarks/Value/LocaleBench.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace MyOnlineStore\Common\Domain\Benchmark\Value;
+
+use MyOnlineStore\Common\Domain\Value\Locale;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+
+/**
+ * @BeforeMethods({"init"})
+ */
+final class LocaleBench
+{
+    /** @var Locale */
+    private $locale;
+
+    /** @var Locale */
+    private $comparator;
+
+    public function init(): void
+    {
+        $this->locale = Locale::fromString('nl_NL');
+        $this->comparator = Locale::fromString('en_GB');
+    }
+
+    /**
+     * @Revs(10000)
+     * @Iterations(5)
+     */
+    public function benchEquals(): void
+    {
+        $this->locale->equals($this->comparator);
+    }
+}


### PR DESCRIPTION
The `Locale::equals` is currently easily called 1000 - 2000 times per request. Therefore I tried (and succeeded) to improve its performance a bit.


First result: current master
Second result: this PR

<img width="911" alt="image" src="https://user-images.githubusercontent.com/2358864/85872441-0ac53b80-b7d0-11ea-950b-375d6e2b31b4.png">

