### PR TITLE
Introduce Street::fromSingleLine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "league/uri": "^5.3",
         "litipk/php-bignumbers": "^0.8.6",
         "moneyphp/money": "^3.3",
-        "ramsey/uuid": "^3.7 || ^4.0",
+        "ramsey/uuid": "^3.7 || ^4.0 <4.1",
         "ronanguilloux/isocodes": "^2.2",
         "webmozart/assert": "^1.8"
     },

--- a/src/Value/Location/Address/Street.php
+++ b/src/Value/Location/Address/Street.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
 use Doctrine\ORM\Mapping as ORM;
+use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * @ORM\Embeddable
@@ -36,6 +37,22 @@ final class Street
         $this->name = $name;
         $this->number = $number;
         $this->suffix = $suffix ? (string) $suffix : null;
+    }
+
+    /**
+     * @throws InvalidArgument
+     */
+    public static function fromSingleLine(string $streetAddress): self
+    {
+        if (\preg_match('/^(\D*[^\d\s]) *([\d]+)(.*)$/', $streetAddress, $results)) {
+            return new self(
+                StreetName::fromString($results[1]),
+                StreetNumber::fromString($results[2]),
+                !empty(\trim($results[3])) ? StreetSuffix::fromString($results[3]) : null
+            );
+        }
+
+        throw new InvalidArgument('Unable to parse single line address');
     }
 
     public function equals(self $operand): bool

--- a/src/Value/Location/Address/Street.php
+++ b/src/Value/Location/Address/Street.php
@@ -44,12 +44,14 @@ final class Street
      */
     public static function fromSingleLine(string $streetAddress): self
     {
-        if (\preg_match('/^(\D*[^\d\s]) *([\d]+)(.*)$/', $streetAddress, $results)) {
-            return new self(
-                StreetName::fromString($results[1]),
-                StreetNumber::fromString($results[2]),
-                !empty(\trim($results[3])) ? StreetSuffix::fromString($results[3]) : null
-            );
+        if (\preg_match('/^(.\D+) *([\d]+)(.*)$/', $streetAddress, $results)) {
+            try {
+                $suffix = StreetSuffix::fromString($results[3]);
+            } catch (InvalidArgument $exception) {
+                $suffix = null;
+            }
+
+            return new self(StreetName::fromString($results[1]), StreetNumber::fromString($results[2]), $suffix);
         }
 
         throw new InvalidArgument('Unable to parse single line address');

--- a/src/Value/Location/Address/StreetName.php
+++ b/src/Value/Location/Address/StreetName.php
@@ -31,7 +31,7 @@ final class StreetName
     {
         Assert::notWhitespaceOnly($name);
 
-        return new self($name);
+        return new self(\trim($name));
     }
 
     public function equals(self $operand): bool

--- a/src/Value/Location/Address/StreetNumber.php
+++ b/src/Value/Location/Address/StreetNumber.php
@@ -31,7 +31,7 @@ final class StreetNumber
     {
         Assert::notWhitespaceOnly($number);
 
-        return new self($number);
+        return new self(\trim($number));
     }
 
     public function equals(self $operand): bool

--- a/src/Value/Location/Address/StreetSuffix.php
+++ b/src/Value/Location/Address/StreetSuffix.php
@@ -23,7 +23,7 @@ final class StreetSuffix
     {
         Assert::notWhitespaceOnly($suffix);
 
-        return new self($suffix);
+        return new self(\trim($suffix));
     }
 
     public function equals(self $operand): bool

--- a/tests/Value/Location/Address/StreetNameTest.php
+++ b/tests/Value/Location/Address/StreetNameTest.php
@@ -12,6 +12,7 @@ final class StreetNameTest extends TestCase
     public function testNotEmpty(): void
     {
         self::assertSame('foo', (string) StreetName::fromString('foo'));
+        self::assertSame('foo', (string) StreetName::fromString(' foo '));
     }
 
     public function emptyDataProvider(): \Generator

--- a/tests/Value/Location/Address/StreetNumberTest.php
+++ b/tests/Value/Location/Address/StreetNumberTest.php
@@ -12,6 +12,7 @@ final class StreetNumberTest extends TestCase
     public function testNotEmpty(): void
     {
         self::assertSame('foo', (string) StreetNumber::fromString('foo'));
+        self::assertSame('foo', (string) StreetNumber::fromString(' foo '));
     }
 
     public function emptyDataProvider(): \Generator

--- a/tests/Value/Location/Address/StreetSuffixTest.php
+++ b/tests/Value/Location/Address/StreetSuffixTest.php
@@ -12,6 +12,7 @@ final class StreetSuffixTest extends TestCase
     public function testNotEmpty(): void
     {
         self::assertSame('foo', (string) StreetSuffix::fromString('foo'));
+        self::assertSame('foo', (string) StreetSuffix::fromString(' foo '));
     }
 
     public function emptyDataProvider(): \Generator

--- a/tests/Value/Location/Address/StreetTest.php
+++ b/tests/Value/Location/Address/StreetTest.php
@@ -102,6 +102,23 @@ final class StreetTest extends TestCase
                 )
             )
         );
+        self::assertTrue(
+            Street::fromSingleLine('3e Haagstraat 135')->equals(
+                new Street(
+                    StreetName::fromString('3e Haagstraat'),
+                    StreetNumber::fromString('135')
+                )
+            )
+        );
+        self::assertTrue(
+            Street::fromSingleLine('3e Haagstraat 135a')->equals(
+                new Street(
+                    StreetName::fromString('3e Haagstraat'),
+                    StreetNumber::fromString('135'),
+                    StreetSuffix::fromString('a')
+                )
+            )
+        );
     }
 
     public function testFromSingleLineFailed(): void

--- a/tests/Value/Location/Address/StreetTest.php
+++ b/tests/Value/Location/Address/StreetTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Tests\Value\Location\Address;
 
+use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 use MyOnlineStore\Common\Domain\Value\Location\Address\Street;
 use MyOnlineStore\Common\Domain\Value\Location\Address\StreetName;
 use MyOnlineStore\Common\Domain\Value\Location\Address\StreetNumber;
@@ -71,6 +72,42 @@ final class StreetTest extends TestCase
                 )
             )
         );
+    }
+
+    public function testFromSingleLine(): void
+    {
+        self::assertTrue(
+            Street::fromSingleLine('foo 12a')->equals(
+                new Street(
+                    StreetName::fromString('foo'),
+                    StreetNumber::fromString('12'),
+                    StreetSuffix::fromString('a')
+                )
+            )
+        );
+        self::assertTrue(
+            Street::fromSingleLine('foo 12 a')->equals(
+                new Street(
+                    StreetName::fromString('foo'),
+                    StreetNumber::fromString('12'),
+                    StreetSuffix::fromString('a')
+                )
+            )
+        );
+        self::assertTrue(
+            Street::fromSingleLine('foo 12')->equals(
+                new Street(
+                    StreetName::fromString('foo'),
+                    StreetNumber::fromString('12')
+                )
+            )
+        );
+    }
+
+    public function testFromSingleLineFailed(): void
+    {
+        $this->expectException(InvalidArgument::class);
+        Street::fromSingleLine('foo');
     }
 
     public function testWithoutSuffix(): void


### PR DESCRIPTION
Introduces a method to parse a single-line street address into the street name, number and extension.
Also, whitespace will be trimmed from the `StreetName|Number|Suffix` VOs.

This is part one of a fix for https://rollbar.com/sandwich/MOS/items/248/