### PR TITLE
Always cast an email address to lowercase

### DIFF
--- a/src/Value/Mail/EmailAddress.php
+++ b/src/Value/Mail/EmailAddress.php
@@ -31,7 +31,7 @@ final class EmailAddress
             throw new InvalidEmailAddress(\sprintf('"%s" is not a valid email address', $emailAddress));
         }
 
-        $this->emailAddress = $emailAddress;
+        $this->emailAddress = \mb_strtolower($emailAddress);
     }
 
     public function equals(self $comparator): bool

--- a/tests/Value/Mail/EmailAddressTest.php
+++ b/tests/Value/Mail/EmailAddressTest.php
@@ -13,6 +13,9 @@ final class EmailAddressTest extends TestCase
     {
         $emailAddress = new EmailAddress('hi@mos.com');
         self::assertEquals('hi@mos.com', (string) $emailAddress);
+
+        $emailAddress = new EmailAddress('Hi@Mos.com');
+        self::assertEquals('hi@mos.com', (string) $emailAddress);
     }
 
     public function testConstructorDoesNotAcceptAnInvalidEmailAddress(): void
@@ -26,6 +29,7 @@ final class EmailAddressTest extends TestCase
         $emailAddress = new EmailAddress('hi@mos.com');
 
         self::assertTrue($emailAddress->equals(new EmailAddress('hi@mos.com')));
+        self::assertTrue($emailAddress->equals(new EmailAddress('Hi@Mos.com')));
         self::assertFalse($emailAddress->equals(new EmailAddress('bye@mos.com')));
     }
 }


### PR DESCRIPTION
This ensures a correct equality check with different casing