### PR TITLE
Add PHP 8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
         strategy:
             matrix:
-                php-version: ['7.2', '7.4']
+                php-version: ['7.2', '7.4', '8.0']
             fail-fast: false
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-bcmath": "*",
         "ext-intl": "*",
-        "egulias/email-validator": "^2.1",
+        "egulias/email-validator": "^2.1 || ^3.1",
         "giggsey/libphonenumber-for-php": "^8.12",
-        "layershifter/tld-extract": "^2.0",
+        "jeremykendall/php-domain-parser": "^5.7",
         "league/uri": "^5.3",
         "litipk/php-bignumbers": "^0.8.6",
         "moneyphp/money": "^3.3",
@@ -31,10 +31,10 @@
     "require-dev": {
         "doctrine/orm": "^2.7",
         "myonlinestore/coding-standard": "^3.0",
-        "phpbench/phpbench": "^0.17.1",
+        "phpbench/phpbench": "dev-master",
         "phpunit/phpunit": "^8.5",
-        "psalm/plugin-phpunit": "^0.12",
-        "vimeo/psalm": "^3.18"
+        "psalm/plugin-phpunit": "^0.15",
+        "vimeo/psalm": "^4.6"
     },
     "config": {
         "sort-packages": true,

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.14.2@3538fe1955d47f6ee926c0769d71af6db08aa488">
+<files psalm-version="4.6.1@e93e532e4eaad6d68c4d7b606853800eaceccc72">
   <file src="src/Assertion/EnumValueGuardTrait.php">
     <InvalidScalarArgument occurrences="1">
       <code>$value</code>
@@ -12,6 +12,9 @@
     <DeprecatedInterface occurrences="1">
       <code>ImmutableCollection</code>
     </DeprecatedInterface>
+    <MissingParamType occurrences="1">
+      <code>$element</code>
+    </MissingParamType>
   </file>
   <file src="src/Collection/ImmutableCollectionInterface.php">
     <DeprecatedClass occurrences="1">
@@ -25,10 +28,13 @@
     <DeprecatedInterface occurrences="1">
       <code>MutableCollection</code>
     </DeprecatedInterface>
+    <MissingParamType occurrences="1">
+      <code>$element</code>
+    </MissingParamType>
     <UnsafeInstantiation occurrences="3">
-      <code>new static(\array_values($this-&gt;toArray()))</code>
       <code>new static(\array_filter($this-&gt;toArray(), $closure))</code>
       <code>new static(\array_map($closure, $this-&gt;toArray()))</code>
+      <code>new static(\array_values($this-&gt;toArray()))</code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Collection/MutableCollectionInterface.php">
@@ -37,9 +43,8 @@
     </MissingReturnType>
   </file>
   <file src="src/Collection/RegionCodeCollection.php">
-    <DeprecatedClass occurrences="5">
+    <DeprecatedClass occurrences="4">
       <code>ImmutableCollection</code>
-      <code>RegionCodeCollectionInterface</code>
       <code>RegionCodeCollectionInterface</code>
       <code>RegionCodeCollectionInterface</code>
     </DeprecatedClass>
@@ -56,12 +61,15 @@
     </LessSpecificImplementedReturnType>
   </file>
   <file src="src/Collection/StoreIds.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;toArray()</code>
+    </ArgumentTypeCoercion>
     <DeprecatedClass occurrences="6">
       <code>ImmutableCollection</code>
-      <code>StoreId[]|int[]</code>
-      <code>new StoreId($entry)</code>
       <code>StoreId</code>
+      <code>StoreId[]|int[]</code>
       <code>StoreIdsInterface</code>
+      <code>new StoreId($entry)</code>
     </DeprecatedClass>
     <DeprecatedInterface occurrences="1">
       <code>StoreIds</code>
@@ -92,55 +100,25 @@
   </file>
   <file src="src/Value/Money/Money.php">
     <ArgumentTypeCoercion occurrences="3">
-      <code>\sprintf('1%s', \str_repeat('0', $currency-&gt;getMinorUnit()))</code>
       <code>(string) $this-&gt;amount</code>
+      <code>\sprintf('1%s', \str_repeat('0', $currency-&gt;getMinorUnit()))</code>
       <code>\sprintf('1%s', \str_repeat('0', $this-&gt;currency-&gt;getMinorUnit()))</code>
     </ArgumentTypeCoercion>
     <InvalidToString occurrences="1">
       <code>string</code>
     </InvalidToString>
     <NullableReturnStatement occurrences="1"/>
-    <PossiblyInvalidArgument occurrences="2">
-      <code>$amount</code>
-      <code>$amount</code>
-    </PossiblyInvalidArgument>
   </file>
   <file src="src/Value/Money/Price.php">
-    <ArgumentTypeCoercion occurrences="25">
-      <code>$this-&gt;amount</code>
-      <code>$other-&gt;amount</code>
-      <code>$percentage</code>
-      <code>$this-&gt;amount</code>
-      <code>$this-&gt;amount</code>
-      <code>$this-&gt;amount</code>
-      <code>$denominator-&gt;amount</code>
-      <code>$this-&gt;amount</code>
+    <ArgumentTypeCoercion occurrences="2">
       <code>(string) $amount</code>
-      <code>$percentage</code>
-      <code>$this-&gt;amount</code>
-      <code>$percentage</code>
-      <code>$percentage</code>
-      <code>$this-&gt;amount</code>
-      <code>$this-&gt;amount</code>
-      <code>$multiplicand-&gt;amount</code>
-      <code>$this-&gt;amount</code>
       <code>(string) $amount</code>
-      <code>$this-&gt;amount</code>
-      <code>$other-&gt;amount</code>
-      <code>$percentage</code>
-      <code>$this-&gt;amount</code>
-      <code>$this-&gt;amount</code>
-      <code>$other-&gt;amount</code>
-      <code>$this-&gt;amount</code>
     </ArgumentTypeCoercion>
-    <InvalidArgument occurrences="1">
-      <code>\bcmul('100.0', $this-&gt;amount, self::PRECISION_CALC)</code>
-    </InvalidArgument>
     <PossiblyNullArgument occurrences="4">
-      <code>$value</code>
-      <code>$value</code>
       <code>$amountPerPercentage</code>
       <code>$priceWithoutPercentage</code>
+      <code>$value</code>
+      <code>$value</code>
     </PossiblyNullArgument>
   </file>
   <file src="src/Value/RegionCode.php">
@@ -148,18 +126,10 @@
       <code>null === $code</code>
     </DocblockTypeContradiction>
   </file>
-  <file src="src/Value/Type/AbstractUuid.php">
-    <UnsafeInstantiation occurrences="4">
-      <code>new static(Uuid::fromBytes($bytes))</code>
-      <code>new static(Uuid::uuid5($namespace, (string) $numericId))</code>
-      <code>new static(Uuid::fromString($string))</code>
-      <code>new static(Uuid::uuid4())</code>
-    </UnsafeInstantiation>
-  </file>
-  <file src="src/Value/Web/DomainName.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>isset(self::$validator)</code>
-    </DocblockTypeContradiction>
+  <file src="src/Value/Web/IPAddress.php">
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(string) $this-&gt;value</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Value/Web/Url.php">
     <DeprecatedInterface occurrences="1">

--- a/src/Value/Money/Money.php
+++ b/src/Value/Money/Money.php
@@ -61,7 +61,7 @@ final class Money
         return new self(
             new Amount(
                 (int) \bcmul(
-                    (string) \round($amount, $currency->getMinorUnit()),
+                    (string) \round((float) $amount, $currency->getMinorUnit()),
                     \sprintf('1%s', \str_repeat('0', $currency->getMinorUnit())),
                     $currency->getMinorUnit()
                 )

--- a/src/Value/Money/Price.php
+++ b/src/Value/Money/Price.php
@@ -81,7 +81,7 @@ final class Price
 
     public function asCents(int $roundingMode = \PHP_ROUND_HALF_EVEN): int
     {
-        return (int) \round(\bcmul('100.0', $this->amount, self::PRECISION_CALC), 0, $roundingMode);
+        return (int) \round((float) \bcmul('100.0', $this->amount, self::PRECISION_CALC), 0, $roundingMode);
     }
 
     public static function asZero(): self

--- a/src/Value/Web/UrlHost.php
+++ b/src/Value/Web/UrlHost.php
@@ -20,7 +20,7 @@ final class UrlHost
      */
     public function __construct($hostname)
     {
-        if (!\filter_var('http://' . $hostname, \FILTER_VALIDATE_URL, \FILTER_FLAG_HOST_REQUIRED)) {
+        if (!\filter_var('http://' . $hostname, \FILTER_VALIDATE_URL)) {
             throw new InvalidHostName(\sprintf('"%s" is not a valid UrlHost', $hostname));
         }
 


### PR DESCRIPTION
- Replaced `layershifter/tld-extract` with `jeremykendall/php-domain-parser`, because the former does not support PHP 8 ánd is abandoned. I don't particularly like the current `DomainName` implementation, but for now kept it as before - functionally.
- Removes the `FILTER_FLAG_HOST_REQUIRED` flag in `UrlHost`. This flag was deprecated in PHP 7.3 and removed in PHP 8. The corresponding behaviour was already implicitly enforced from PHP 5.2.1 onward, thus nothing changes here.
- A couple of `(float)` casts were added in `round()` calls, as this type is enforced starting from PHP 8.