### PR TITLE
Replaced final keyword with annotation in immutable classes

### DIFF
--- a/src/Value/Contact/EmailAddress.php
+++ b/src/Value/Contact/EmailAddress.php
@@ -6,9 +6,10 @@ namespace MyOnlineStore\Common\Domain\Value\Contact;
 use MyOnlineStore\Common\Domain\Exception\Mail\InvalidEmailAddress;
 
 /**
+ * @final
  * @psalm-immutable
  */
-final class EmailAddress
+class EmailAddress
 {
     private function __construct(
         private string $emailAddress

--- a/src/Value/Contact/PhoneNumber.php
+++ b/src/Value/Contact/PhoneNumber.php
@@ -12,9 +12,10 @@ use MyOnlineStore\Common\Domain\Exception\Contact\InvalidPhoneNumber;
 use MyOnlineStore\Common\Domain\Value\RegionCode;
 
 /**
+ * @final
  * @psalm-immutable
  */
-final class PhoneNumber
+class PhoneNumber
 {
     private PhoneNumberUtil $phoneNumberUtil;
     private LibPhoneNumber $value;

--- a/src/Value/Finance/Bic.php
+++ b/src/Value/Finance/Bic.php
@@ -7,9 +7,10 @@ use IsoCodes\SwiftBic;
 use MyOnlineStore\Common\Domain\Exception\Finance\InvalidBic;
 
 /**
+ * @final
  * @psalm-immutable
  */
-final class Bic
+class Bic
 {
     private function __construct(
         private string $bic

--- a/src/Value/Finance/Iban.php
+++ b/src/Value/Finance/Iban.php
@@ -7,9 +7,10 @@ use IsoCodes\Iban as IbanValidator;
 use MyOnlineStore\Common\Domain\Exception\Finance\InvalidIban;
 
 /**
+ * @final
  * @psalm-immutable
  */
-final class Iban
+class Iban
 {
     public function __construct(
         private string $iban

--- a/src/Value/LanguageCode.php
+++ b/src/Value/LanguageCode.php
@@ -8,9 +8,10 @@ use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 /**
  * ISO 639 code (https://en.wikipedia.org/wiki/ISO_639)
  *
+ * @final
  * @psalm-immutable
  */
-final class LanguageCode
+class LanguageCode
 {
     private function __construct(
         private string $code

--- a/src/Value/Locale.php
+++ b/src/Value/Locale.php
@@ -6,9 +6,10 @@ namespace MyOnlineStore\Common\Domain\Value;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
+ * @final
  * @psalm-immutable
  */
-final class Locale
+class Locale
 {
     public function __construct(
         public LanguageCode $languageCode,

--- a/src/Value/RegionCode.php
+++ b/src/Value/RegionCode.php
@@ -8,9 +8,10 @@ use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 /**
  * ISO 3166-1 alpha-2 code (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
  *
+ * @final
  * @psalm-immutable
  */
-final class RegionCode
+class RegionCode
 {
     private function __construct(
         private string $code

--- a/src/Value/Tax/VatNumber.php
+++ b/src/Value/Tax/VatNumber.php
@@ -6,9 +6,10 @@ namespace MyOnlineStore\Common\Domain\Value\Tax;
 use MyOnlineStore\Common\Domain\Exception\Tax\InvalidVatNumber;
 
 /**
+ * @final
  * @psalm-immutable
  */
-final class VatNumber
+class VatNumber
 {
     private function __construct(
         private string $vatNumber

--- a/src/Value/Web/IPAddress.php
+++ b/src/Value/Web/IPAddress.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 namespace MyOnlineStore\Common\Domain\Value\Web;
 
 /**
+ * @final
  * @psalm-immutable
  */
-final class IPAddress
+class IPAddress
 {
     public const IPV4 = 'IPv4';
     public const IPV6 = 'IPv6';


### PR DESCRIPTION
This allows these classes to be mocked in applications using Infection, which is especially welcome for classes like `VatNumber` which otherwise requires a validator instance to be constructed/inject at every test that uses it.