### PR TITLE
chore: Defined Valinor mapping constructors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
         strategy:
             matrix:
-                php-version: ['7.2', '7.4', '8.0']
+                php-version: ['7.4', '8.0']
             fail-fast: false
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.4 || ^8.0",
         "ext-bcmath": "*",
         "ext-intl": "*",
-        "cuyz/valinor": "dev-master",
+        "cuyz/valinor": "^0.5.0",
         "egulias/email-validator": "^2.1 || ^3.1",
         "giggsey/libphonenumber-for-php": "^8.12",
         "jeremykendall/php-domain-parser": "^5.7",

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,12 @@
     "description": "Common MyOnlineStore domain concepts",
     "homepage": "https://github.com/MyOnlineStore/common-domain",
     "license": "MIT",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/MyOnlineStore/Valinor.git"
+        }
+    ],
     "autoload": {
         "psr-4": {
             "MyOnlineStore\\Common\\Domain\\": "src/"
@@ -16,9 +22,10 @@
         }
     },
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-bcmath": "*",
         "ext-intl": "*",
+        "cuyz/valinor": "dev-fix-attributes-index",
         "egulias/email-validator": "^2.1 || ^3.1",
         "giggsey/libphonenumber-for-php": "^8.12",
         "jeremykendall/php-domain-parser": "^5.7",
@@ -32,7 +39,7 @@
     "require-dev": {
         "doctrine/orm": "^2.7",
         "myonlinestore/coding-standard": "^3.0",
-        "phpbench/phpbench": "dev-master",
+        "phpbench/phpbench": "^1.1",
         "phpunit/phpunit": "^8.5",
         "psalm/plugin-phpunit": "^0.15",
         "vimeo/psalm": "^4.6"
@@ -40,7 +47,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "7.2.24"
+            "php": "7.4.24"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,6 @@
     "description": "Common MyOnlineStore domain concepts",
     "homepage": "https://github.com/MyOnlineStore/common-domain",
     "license": "MIT",
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/MyOnlineStore/Valinor.git"
-        }
-    ],
     "autoload": {
         "psr-4": {
             "MyOnlineStore\\Common\\Domain\\": "src/"
@@ -25,7 +19,7 @@
         "php": "^7.4 || ^8.0",
         "ext-bcmath": "*",
         "ext-intl": "*",
-        "cuyz/valinor": "dev-fix-attributes-index",
+        "cuyz/valinor": "dev-master",
         "egulias/email-validator": "^2.1 || ^3.1",
         "giggsey/libphonenumber-for-php": "^8.12",
         "jeremykendall/php-domain-parser": "^5.7",

--- a/composer.json
+++ b/composer.json
@@ -45,9 +45,6 @@
         "vimeo/psalm": "^4.6"
     },
     "config": {
-        "sort-packages": true,
-        "platform": {
-            "php": "7.4.24"
-        }
+        "sort-packages": true
     }
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 
-<psalm allowPhpStormGenerics="true"
-       errorBaseline="psalm-baseline.xml"
+<psalm errorBaseline="psalm-baseline.xml"
        errorLevel="2"
        resolveFromConfigFile="true"
        totallyTyped="true"

--- a/src/Value/Arithmetic/Amount.php
+++ b/src/Value/Arithmetic/Amount.php
@@ -35,6 +35,13 @@ final class Amount extends Number
         parent::__construct($value, 0);
     }
 
+    public function toInt(): int
+    {
+        /** @psalm-suppress ImpureMethodCall */
+
+        return $this->value->asInteger();
+    }
+
     /**
      * @psalm-pure
      */

--- a/src/Value/Arithmetic/Percentage.php
+++ b/src/Value/Arithmetic/Percentage.php
@@ -3,11 +3,14 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Arithmetic;
 
+use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * @ORM\Embeddable
+ *
+ * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Color/HexColor.php
+++ b/src/Value/Color/HexColor.php
@@ -3,9 +3,12 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Color;
 
+use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use MyOnlineStore\Common\Domain\Exception\Color\InvalidHexColor;
 
 /**
+ * @StaticMethodConstructor("fromString")
+ *
  * @final
  * @psalm-immutable
  */

--- a/src/Value/Contact/PhoneNumber.php
+++ b/src/Value/Contact/PhoneNumber.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Contact;
 
+use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumber as LibPhoneNumber;
 use libphonenumber\PhoneNumberFormat;
@@ -11,6 +12,8 @@ use libphonenumber\PhoneNumberUtil;
 use MyOnlineStore\Common\Domain\Value\RegionCode;
 
 /**
+ * @StaticMethodConstructor("fromString")
+ *
  * @psalm-immutable
  */
 final class PhoneNumber
@@ -44,6 +47,11 @@ final class PhoneNumber
                 $exception
             );
         }
+    }
+
+    public static function fromString(string $value): self
+    {
+        return new self($value);
     }
 
     public function __toString(): string

--- a/src/Value/Finance/Bic.php
+++ b/src/Value/Finance/Bic.php
@@ -3,10 +3,13 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Finance;
 
+use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use IsoCodes\SwiftBic;
 use MyOnlineStore\Common\Domain\Exception\Finance\InvalidBic;
 
 /**
+ * @StaticMethodConstructor("fromString")
+ *
  * @psalm-immutable
  */
 final class Bic

--- a/src/Value/Locale.php
+++ b/src/Value/Locale.php
@@ -2,11 +2,14 @@
 
 namespace MyOnlineStore\Common\Domain\Value;
 
+use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * @ORM\Embeddable
+ *
+ * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Location/Address/City.php
+++ b/src/Value/Location/Address/City.php
@@ -3,12 +3,15 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
+use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * @ORM\Embeddable
+ *
+ * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Location/Address/StreetName.php
+++ b/src/Value/Location/Address/StreetName.php
@@ -3,12 +3,15 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
+use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * @ORM\Embeddable
+ *
+ * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Location/Address/StreetNumber.php
+++ b/src/Value/Location/Address/StreetNumber.php
@@ -3,12 +3,15 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
+use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * @ORM\Embeddable
+ *
+ * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Location/Address/StreetSuffix.php
+++ b/src/Value/Location/Address/StreetSuffix.php
@@ -3,10 +3,13 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
+use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
+ * @StaticMethodConstructor("fromString")
+ *
  * @psalm-immutable
  */
 final class StreetSuffix

--- a/src/Value/Location/Address/ZipCode.php
+++ b/src/Value/Location/Address/ZipCode.php
@@ -3,12 +3,15 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
+use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * @ORM\Embeddable
+ *
+ * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Money/CurrencyIso.php
+++ b/src/Value/Money/CurrencyIso.php
@@ -3,11 +3,14 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Money;
 
+use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Exception\Currency\InvalidCurrencyIso;
 
 /**
  * @ORM\Embeddable
+ *
+ * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Person/BirthDate.php
+++ b/src/Value/Person/BirthDate.php
@@ -3,10 +3,13 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Person;
 
+use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Embeddable
+ *
+ * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */
@@ -27,6 +30,19 @@ final class BirthDate
     }
 
     /**
+     * @psalm-suppress InvalidToString
+     */
+    public function __toString(): string
+    {
+        return $this->date->format(self::FORMAT);
+    }
+
+    public function equals(self $comparator): bool
+    {
+        return (string) $this === (string) $comparator;
+    }
+
+    /**
      * @psalm-pure
      */
     public static function fromDateTime(\DateTimeImmutable $date): self
@@ -37,30 +53,25 @@ final class BirthDate
     /**
      * @psalm-pure
      */
-    public static function fromString(
-        string $time,
+    public static function fromString(string $date): self
+    {
+        return self::fromStringWithFormat($date);
+    }
+
+    /**
+     * @psalm-pure
+     */
+    public static function fromStringWithFormat(
+        string $date,
         string $format = self::FORMAT
     ): self {
         /** @psalm-suppress PossiblyFalseArgument */
 
-        return new self(\DateTimeImmutable::createFromFormat($format, $time));
-    }
-
-    public function equals(self $comparator): bool
-    {
-        return (string) $this === (string) $comparator;
+        return new self(\DateTimeImmutable::createFromFormat($format, $date));
     }
 
     public function getDate(): \DateTimeImmutable
     {
         return $this->date;
-    }
-
-    /**
-     * @psalm-suppress InvalidToString
-     */
-    public function __toString(): string
-    {
-        return $this->date->format(self::FORMAT);
     }
 }

--- a/src/Value/Person/Gender.php
+++ b/src/Value/Person/Gender.php
@@ -3,11 +3,14 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Person;
 
+use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Exception\Person\InvalidGender;
 
 /**
  * @ORM\Embeddable
+ *
+ * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Person/Name.php
+++ b/src/Value/Person/Name.php
@@ -28,10 +28,10 @@ final class Name
      */
     private $lastName;
 
-    public function __construct(FirstName $firstName, LastName $lastName)
+    public function __construct(FirstName $first, LastName $last)
     {
-        $this->firstName = $firstName;
-        $this->lastName = $lastName;
+        $this->firstName = $first;
+        $this->lastName = $last;
     }
 
     public function equals(self $operand): bool

--- a/src/Value/Person/Name/FirstName.php
+++ b/src/Value/Person/Name/FirstName.php
@@ -3,12 +3,15 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Person\Name;
 
+use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * @ORM\Embeddable
+ *
+ * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Person/Name/LastName.php
+++ b/src/Value/Person/Name/LastName.php
@@ -3,12 +3,15 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Person\Name;
 
+use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * @ORM\Embeddable
+ *
+ * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Web/Url.php
+++ b/src/Value/Web/Url.php
@@ -3,10 +3,13 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Web;
 
+use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use League\Uri\Http;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
+ * @StaticMethodConstructor("fromString")
+ *
  * @psalm-immutable
  */
 final class Url extends Http

--- a/tests/Value/Contact/PhoneNumberTest.php
+++ b/tests/Value/Contact/PhoneNumberTest.php
@@ -143,9 +143,9 @@ final class PhoneNumberTest extends TestCase
         self::assertFalse((new PhoneNumber('112'))->isMobile());
     }
 
-    public function testToString(): void
+    public function testStringConversion(): void
     {
-        $phoneNumber = new PhoneNumber('0031882315726');
+        $phoneNumber = PhoneNumber::fromString('0031882315726');
         self::assertEquals($phoneNumber->getShortInternationalFormat(), (string) $phoneNumber);
     }
 

--- a/tests/Value/Person/BirthDateTest.php
+++ b/tests/Value/Person/BirthDateTest.php
@@ -20,6 +20,18 @@ final class BirthDateTest extends TestCase
         self::assertSame($date, (string) $birthDate);
     }
 
+    public function testFromStringWithFormat(): void
+    {
+        $date = '18-10-2019';
+        $birthDate = BirthDate::fromStringWithFormat($date, 'd-m-Y');
+
+        self::assertEquals(
+            \DateTimeImmutable::createFromFormat('d-m-Y', $date),
+            $birthDate->getDate()
+        );
+        self::assertSame('2019-10-18', (string) $birthDate);
+    }
+
     public function testFromDateTime(): void
     {
         $birthDate = BirthDate::fromDateTime($date = new \DateTimeImmutable());
@@ -28,7 +40,7 @@ final class BirthDateTest extends TestCase
 
     public function testEquals(): void
     {
-        self::assertTrue(BirthDate::fromString('2019-10-18')->equals(BirthDate::fromString('2019-10-18')));
-        self::assertFalse(BirthDate::fromString('2019-10-18')->equals(BirthDate::fromString('2019-10-19')));
+        self::assertTrue(BirthDate::fromStringWithFormat('2019-10-18')->equals(BirthDate::fromStringWithFormat('2019-10-18')));
+        self::assertFalse(BirthDate::fromStringWithFormat('2019-10-18')->equals(BirthDate::fromStringWithFormat('2019-10-19')));
     }
 }


### PR DESCRIPTION
- [x] https://github.com/CuyZ/Valinor/pull/63 (to allow Valinor annotations to be defined after other annotations)

These annotations are required by an upcoming payment PR.

Strictly speaking the `BirthDate::fromString` change is not backwards compatible, and therefore a new major version should be released.