### PR TITLE
chore: Reduced number of StaticMethodConstructor annotations

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -3,7 +3,6 @@
 <psalm errorBaseline="psalm-baseline.xml"
        errorLevel="2"
        resolveFromConfigFile="true"
-       totallyTyped="true"
        usePhpDocMethodsWithoutMagicCall="true"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns="https://getpsalm.org/schema/config"

--- a/src/Value/Arithmetic/Percentage.php
+++ b/src/Value/Arithmetic/Percentage.php
@@ -3,14 +3,11 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Arithmetic;
 
-use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * @ORM\Embeddable
- *
- * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Color/HexColor.php
+++ b/src/Value/Color/HexColor.php
@@ -3,12 +3,9 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Color;
 
-use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use MyOnlineStore\Common\Domain\Exception\Color\InvalidHexColor;
 
 /**
- * @StaticMethodConstructor("fromString")
- *
  * @final
  * @psalm-immutable
  */

--- a/src/Value/Contact/PhoneNumber.php
+++ b/src/Value/Contact/PhoneNumber.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Contact;
 
-use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumber as LibPhoneNumber;
 use libphonenumber\PhoneNumberFormat;
@@ -12,8 +11,6 @@ use libphonenumber\PhoneNumberUtil;
 use MyOnlineStore\Common\Domain\Value\RegionCode;
 
 /**
- * @StaticMethodConstructor("fromString")
- *
  * @psalm-immutable
  */
 final class PhoneNumber

--- a/src/Value/Finance/Bic.php
+++ b/src/Value/Finance/Bic.php
@@ -3,13 +3,10 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Finance;
 
-use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use IsoCodes\SwiftBic;
 use MyOnlineStore\Common\Domain\Exception\Finance\InvalidBic;
 
 /**
- * @StaticMethodConstructor("fromString")
- *
  * @psalm-immutable
  */
 final class Bic

--- a/src/Value/Locale.php
+++ b/src/Value/Locale.php
@@ -2,14 +2,11 @@
 
 namespace MyOnlineStore\Common\Domain\Value;
 
-use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * @ORM\Embeddable
- *
- * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Location/Address/City.php
+++ b/src/Value/Location/Address/City.php
@@ -3,15 +3,12 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
-use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * @ORM\Embeddable
- *
- * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Location/Address/StreetName.php
+++ b/src/Value/Location/Address/StreetName.php
@@ -3,15 +3,12 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
-use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * @ORM\Embeddable
- *
- * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Location/Address/StreetNumber.php
+++ b/src/Value/Location/Address/StreetNumber.php
@@ -3,15 +3,12 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
-use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * @ORM\Embeddable
- *
- * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Location/Address/StreetSuffix.php
+++ b/src/Value/Location/Address/StreetSuffix.php
@@ -3,13 +3,10 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
-use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @StaticMethodConstructor("fromString")
- *
  * @psalm-immutable
  */
 final class StreetSuffix

--- a/src/Value/Location/Address/ZipCode.php
+++ b/src/Value/Location/Address/ZipCode.php
@@ -3,15 +3,12 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
-use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * @ORM\Embeddable
- *
- * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Money/CurrencyIso.php
+++ b/src/Value/Money/CurrencyIso.php
@@ -3,14 +3,11 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Money;
 
-use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Exception\Currency\InvalidCurrencyIso;
 
 /**
  * @ORM\Embeddable
- *
- * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Person/BirthDate.php
+++ b/src/Value/Person/BirthDate.php
@@ -19,10 +19,8 @@ final class BirthDate
 
     /**
      * @ORM\Column(name="birth_date", type="date_immutable")
-     *
-     * @var \DateTimeImmutable
      */
-    private $date;
+    private \DateTimeImmutable $date;
 
     private function __construct(\DateTimeImmutable $date)
     {

--- a/src/Value/Person/Gender.php
+++ b/src/Value/Person/Gender.php
@@ -3,14 +3,11 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Person;
 
-use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Exception\Person\InvalidGender;
 
 /**
  * @ORM\Embeddable
- *
- * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Person/Name/FirstName.php
+++ b/src/Value/Person/Name/FirstName.php
@@ -3,15 +3,12 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Person\Name;
 
-use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * @ORM\Embeddable
- *
- * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Person/Name/LastName.php
+++ b/src/Value/Person/Name/LastName.php
@@ -3,15 +3,12 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Person\Name;
 
-use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * @ORM\Embeddable
- *
- * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */


### PR DESCRIPTION
The only remaining value object using the annotation are `BirthDate` and `Url`.