### PR TITLE
chore: Convert null values to zero

### DIFF
--- a/src/Value/Arithmetic/Amount.php
+++ b/src/Value/Arithmetic/Amount.php
@@ -32,7 +32,7 @@ final class Amount extends Number
             throw new InvalidArgument(\sprintf('Amount must be a whole number, "%s" given', $value));
         }
 
-        parent::__construct($value, 0);
+        parent::__construct($value ?? 0, 0);
     }
 
     public function toInt(): int


### PR DESCRIPTION
Without this change an error would be thrown by the BigDecimal package when a null value is provided. While it seems this error doesn't currently pose a problem anywhere, it will become an issue when used in combination with Valinor (which won't be able to convert this situation to a Valinor mapping error, as used in https://github.com/MyOnlineStore/payment/pull/328).