### PR TITLE
chore: Updated valinor from 0.5 to 0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.4 || ^8.0",
         "ext-bcmath": "*",
         "ext-intl": "*",
-        "cuyz/valinor": "^0.5.0",
+        "cuyz/valinor": "^0.6",
         "egulias/email-validator": "^2.1 || ^3.1",
         "giggsey/libphonenumber-for-php": "^8.12",
         "jeremykendall/php-domain-parser": "^5.7",

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,17 @@
             "MyOnlineStore\\Common\\Domain\\Tests\\": "tests/"
         }
     },
+    "config": {
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-bcmath": "*",
         "ext-intl": "*",
-        "cuyz/valinor": "^0.6",
+        "cuyz/valinor": "^0.7",
         "egulias/email-validator": "^2.1 || ^3.1",
         "giggsey/libphonenumber-for-php": "^8.12",
         "jeremykendall/php-domain-parser": "^5.7",
@@ -27,18 +33,15 @@
         "litipk/php-bignumbers": "^0.8.6",
         "moneyphp/money": "^3.3",
         "ramsey/uuid": "^3.7 || ^4.0 <4.1",
-        "ronanguilloux/isocodes": "^2.2",
-        "webmozart/assert": "^1.8"
+        "ronanguilloux/isocodes": "^2.3",
+        "webmozart/assert": "^1.10"
     },
     "require-dev": {
-        "doctrine/orm": "^2.7",
-        "myonlinestore/coding-standard": "^3.0",
-        "phpbench/phpbench": "^1.1",
+        "doctrine/orm": "^2.12",
+        "myonlinestore/coding-standard": "^3.1",
+        "phpbench/phpbench": "^1.2",
         "phpunit/phpunit": "^8.5",
-        "psalm/plugin-phpunit": "^0.15",
-        "vimeo/psalm": "^4.6"
-    },
-    "config": {
-        "sort-packages": true
+        "psalm/plugin-phpunit": "^0.16",
+        "vimeo/psalm": "^4.22"
     }
 }


### PR DESCRIPTION
Should be tagged as `2.5.3`

This updated is required to get the `api-tools` package installed in the monolith.