### PR TITLE
chore!: Remove valinor annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "php": "^7.4 || ^8.0",
         "ext-bcmath": "*",
         "ext-intl": "*",
-        "cuyz/valinor": "^0.7",
         "egulias/email-validator": "^2.1 || ^3.1",
         "giggsey/libphonenumber-for-php": "^8.12",
         "jeremykendall/php-domain-parser": "^5.7",

--- a/src/Value/Person/BirthDate.php
+++ b/src/Value/Person/BirthDate.php
@@ -3,13 +3,10 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Person;
 
-use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Embeddable
- *
- * @StaticMethodConstructor("fromString")
  *
  * @psalm-immutable
  */

--- a/src/Value/Web/Url.php
+++ b/src/Value/Web/Url.php
@@ -3,13 +3,10 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Web;
 
-use CuyZ\Valinor\Attribute\StaticMethodConstructor;
 use League\Uri\Http;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @StaticMethodConstructor("fromString")
- *
  * @psalm-immutable
  */
 final class Url extends Http


### PR DESCRIPTION
These are no longer used upstream. Removing valinor here will ease the
dependency graph and allow upstream services/packages to define the version
to use.

- [x] https://github.com/MyOnlineStore/payment/pull/368