### PR TITLE
fix: Add correct typing to `ImmutableCollection::offsetSet()`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
         strategy:
             matrix:
-                php-version: ['7.4', '8.0']
+                php-version: ['8.0', '8.1']
             fail-fast: false
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,12 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "infection/extension-installer": true
         }
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-bcmath": "*",
         "ext-intl": "*",
         "egulias/email-validator": "^2.1 || ^3.1",

--- a/src/Collection/ImmutableCollection.php
+++ b/src/Collection/ImmutableCollection.php
@@ -9,7 +9,7 @@ namespace MyOnlineStore\Common\Domain\Collection;
 class ImmutableCollection extends MutableCollection
 {
     /**
-     * @inheritDoc 
+     * @inheritDoc
      *
      * @return void
      */
@@ -18,10 +18,7 @@ class ImmutableCollection extends MutableCollection
         throw new \LogicException(\sprintf('Method %s is not available on immutable collections', __FUNCTION__));
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function offsetSet($index, $newval)
+    public function offsetSet(mixed $key, mixed $value): void
     {
         throw new \LogicException(\sprintf('Method %s is not available on immutable collections', __FUNCTION__));
     }


### PR DESCRIPTION
Drop PHP 7.4 support

Method isn't overridden (in the monolith), thus types can be added without breaking anything.
Appears to break preloading: https://grafana.myonlinestore.dev/d/4Ji47I0Gk/services?orgId=1&var-namespace=All&var-pod=All&var-container=All&from=now-30m&to=now&var-app=monolith-api-service-20220718093544