### PR TITLE
chore: Improve `collection::isEmpty()` typing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,20 +29,20 @@
         "egulias/email-validator": "^3.2",
         "giggsey/libphonenumber-for-php": "^8.12",
         "jeremykendall/php-domain-parser": "^6.1",
-        "league/uri": "^6.7",
+        "league/uri": "^6.8",
         "litipk/php-bignumbers": "^0.8.6",
         "moneyphp/money": "^4.0",
-        "ramsey/uuid": "^4.3",
+        "ramsey/uuid": "^4.5",
         "ronanguilloux/isocodes": "^2.3",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {
-        "doctrine/orm": "^2.12",
-        "myonlinestore/coding-standard": "^3.1",
+        "doctrine/orm": "^2.13",
+        "myonlinestore/coding-standard": "^4.0",
         "phpbench/phpbench": "^1.2",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.17",
         "symfony/phpunit-bridge": "^6.1",
-        "vimeo/psalm": "^4.24"
+        "vimeo/psalm": "^4.29"
     }
 }

--- a/src/Assertion/ArrayContainsClassAssertionTrait.php
+++ b/src/Assertion/ArrayContainsClassAssertionTrait.php
@@ -10,9 +10,7 @@ namespace MyOnlineStore\Common\Domain\Assertion;
  */
 trait ArrayContainsClassAssertionTrait
 {
-    /**
-     * @param mixed[] $entries
-     */
+    /** @param mixed[] $entries */
     public function assertArrayContainsOnlyClass(array $entries, string $className): bool
     {
         foreach ($entries as $entry) {

--- a/src/Assertion/Assert.php
+++ b/src/Assertion/Assert.php
@@ -6,9 +6,7 @@ namespace MyOnlineStore\Common\Domain\Assertion;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 use Webmozart\Assert\Assert as WebmozartAssert;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class Assert extends WebmozartAssert
 {
     /**

--- a/src/Assertion/EnumValueGuardTrait.php
+++ b/src/Assertion/EnumValueGuardTrait.php
@@ -3,15 +3,13 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Assertion;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 trait EnumValueGuardTrait
 {
     /**
      * @param mixed $value
      *
-     * @return mixed
+     * @return scalar
      *
      * @throws \InvalidArgumentException
      */
@@ -19,7 +17,7 @@ trait EnumValueGuardTrait
     {
         if (!\is_scalar($value)) {
             throw new \InvalidArgumentException(
-                \sprintf('given value is not a scalar value but of type %s', \gettype($value))
+                \sprintf('given value is not a scalar value but of type %s', \gettype($value)),
             );
         }
 
@@ -31,8 +29,8 @@ trait EnumValueGuardTrait
                     'Invalid %s value given: "%s" (valid values: %s)',
                     self::class,
                     $value,
-                    \implode(', ', $validValues)
-                )
+                    \implode(', ', $validValues),
+                ),
             );
         }
 
@@ -40,7 +38,7 @@ trait EnumValueGuardTrait
     }
 
     /**
-     * @return mixed[]
+     * @return scalar[]
      *
      * @psalm-pure
      */

--- a/src/Assertion/NumericAssertionTrait.php
+++ b/src/Assertion/NumericAssertionTrait.php
@@ -2,9 +2,7 @@
 
 namespace MyOnlineStore\Common\Domain\Assertion;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 trait NumericAssertionTrait
 {
     /**

--- a/src/Collection/ImmutableCollection.php
+++ b/src/Collection/ImmutableCollection.php
@@ -4,17 +4,13 @@ declare(strict_types=1);
 namespace MyOnlineStore\Common\Domain\Collection;
 
 /**
- * @deprecated Should be moved to common-collection
- *
  * @template TKey of array-key
  * @template T
  * @extends  MutableCollection<TKey, T>
  */
 class ImmutableCollection extends MutableCollection
 {
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function add($element)
     {
         throw new \LogicException(\sprintf('Method %s is not available on immutable collections', __FUNCTION__));

--- a/src/Collection/ImmutableCollectionInterface.php
+++ b/src/Collection/ImmutableCollectionInterface.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 namespace MyOnlineStore\Common\Domain\Collection;
 
 /**
- * @deprecated Should be moved to common-collection
- *
  * @template TKey of array-key
  * @template T
  * @implements \IteratorAggregate<TKey, T>
@@ -20,9 +18,7 @@ interface ImmutableCollectionInterface extends \ArrayAccess, \Countable, \Iterat
      */
     public function contains($element);
 
-    /**
-     * @param callable(T): void $callback
-     */
+    /** @param callable(T): void $callback */
     public function each(callable $callback);
 
     /**
@@ -30,9 +26,7 @@ interface ImmutableCollectionInterface extends \ArrayAccess, \Countable, \Iterat
      */
     public function equals(ImmutableCollectionInterface $otherCollection): bool;
 
-    /**
-     * @return T|false
-     */
+    /** @return T|false */
     public function first();
 
     /**
@@ -44,6 +38,9 @@ interface ImmutableCollectionInterface extends \ArrayAccess, \Countable, \Iterat
 
     /**
      * @return bool
+     *
+     * @psalm-assert-if-false T $this->first()
+     * @psalm-assert-if-false T $this->last()
      */
     public function isEmpty();
 
@@ -54,13 +51,9 @@ interface ImmutableCollectionInterface extends \ArrayAccess, \Countable, \Iterat
      */
     public function last();
 
-    /**
-     * @return static
-     */
+    /** @return static */
     public function reindex();
 
-    /**
-     * @return array<TKey, T>
-     */
+    /** @return array<TKey, T> */
     public function toArray();
 }

--- a/src/Collection/MutableCollection.php
+++ b/src/Collection/MutableCollection.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 namespace MyOnlineStore\Common\Domain\Collection;
 
 /**
- * @deprecated Should be moved to common-collection
- *
  * @template TKey of array-key
  * @template T
  * @implements MutableCollectionInterface<TKey, T>
@@ -13,33 +11,25 @@ namespace MyOnlineStore\Common\Domain\Collection;
  */
 class MutableCollection extends \ArrayObject implements MutableCollectionInterface
 {
-    /**
-     * @param array<TKey,T> $entries
-     */
+    /** @param array<TKey,T> $entries */
     public function __construct(array $entries = [])
     {
         parent::__construct($entries);
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function add($element)
     {
         $this->append($element);
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function contains($element)
     {
         return \in_array($element, $this->getArrayCopy(), true);
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function each(callable $callback)
     {
         foreach ($this as $entry) {
@@ -66,9 +56,7 @@ class MutableCollection extends \ArrayObject implements MutableCollectionInterfa
         return true;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function first()
     {
         $arrayCopy = $this->getArrayCopy();
@@ -76,25 +64,19 @@ class MutableCollection extends \ArrayObject implements MutableCollectionInterfa
         return \reset($arrayCopy);
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function indexOf($element)
     {
         return \array_search($element, $this->getArrayCopy(), true);
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function isEmpty()
     {
         return 0 === $this->count();
     }
 
-    /**
-     * @inheritdoc
-     */
+    /** @inheritdoc */
     public function last()
     {
         $arrayCopy = $this->getArrayCopy();
@@ -102,25 +84,19 @@ class MutableCollection extends \ArrayObject implements MutableCollectionInterfa
         return \end($arrayCopy);
     }
 
-    /**
-     * @inheritdoc
-     */
+    /** @inheritdoc */
     public function reindex()
     {
         return new static(\array_values($this->toArray()));
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function toArray()
     {
         return $this->getArrayCopy();
     }
 
-    /**
-     * @param callable(T): bool $callback
-     */
+    /** @param callable(T): bool $callback */
     protected function containsWith(callable $callback): bool
     {
         foreach ($this as $entry) {

--- a/src/Collection/MutableCollectionInterface.php
+++ b/src/Collection/MutableCollectionInterface.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 namespace MyOnlineStore\Common\Domain\Collection;
 
 /**
- * @deprecated Should be moved to common-collection
- *
  * @template TKey of array-key
  * @template T
  * @extends ImmutableCollectionInterface<TKey, T>

--- a/src/Collection/RegionCodeCollection.php
+++ b/src/Collection/RegionCodeCollection.php
@@ -6,17 +6,14 @@ namespace MyOnlineStore\Common\Domain\Collection;
 use MyOnlineStore\Common\Domain\Value\RegionCode;
 
 /**
- * @deprecated Should be moved to common-collection
- *
  * @extends ImmutableCollection<array-key, RegionCode>
+ * @use StringCollectionTrait<array-key, RegionCode>
  */
 final class RegionCodeCollection extends ImmutableCollection implements RegionCodeCollectionInterface
 {
     use StringCollectionTrait;
 
-    /**
-     * @inheritdoc
-     */
+    /** @inheritdoc */
     public function __construct(array $entries = [])
     {
         parent::__construct(
@@ -24,14 +21,12 @@ final class RegionCodeCollection extends ImmutableCollection implements RegionCo
                 $entries,
                 static function ($entry) {
                     return $entry instanceof RegionCode;
-                }
-            )
+                },
+            ),
         );
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function contains($element): bool
     {
         return \in_array($element, $this->getArrayCopy());
@@ -42,9 +37,7 @@ final class RegionCodeCollection extends ImmutableCollection implements RegionCo
         return new self(\array_unique($this->toArray()));
     }
 
-    /**
-     * @param string[] $isoCodes
-     */
+    /** @param string[] $isoCodes */
     public static function fromStrings(array $isoCodes): RegionCodeCollectionInterface
     {
         return new self(
@@ -52,8 +45,8 @@ final class RegionCodeCollection extends ImmutableCollection implements RegionCo
                 static function ($isoCode) {
                     return new RegionCode($isoCode);
                 },
-                $isoCodes
-            )
+                $isoCodes,
+            ),
         );
     }
 }

--- a/src/Collection/RegionCodeCollectionInterface.php
+++ b/src/Collection/RegionCodeCollectionInterface.php
@@ -5,20 +5,12 @@ namespace MyOnlineStore\Common\Domain\Collection;
 
 use MyOnlineStore\Common\Domain\Value\RegionCode;
 
-/**
- * @method RegionCode[] getIterator()
- *
- * @deprecated Should be moved to common-collection
- */
+/** @method RegionCode[] getIterator() */
 interface RegionCodeCollectionInterface extends ImmutableCollectionInterface, StringCollectionInterface
 {
-    /**
-     * @return RegionCodeCollectionInterface
-     */
+    /** @return RegionCodeCollectionInterface */
     public function reindex();
 
-    /**
-     * @return RegionCodeCollectionInterface
-     */
+    /** @return RegionCodeCollectionInterface */
     public function unique(): RegionCodeCollectionInterface;
 }

--- a/src/Collection/StoreIds.php
+++ b/src/Collection/StoreIds.php
@@ -6,17 +6,14 @@ namespace MyOnlineStore\Common\Domain\Collection;
 use MyOnlineStore\Common\Domain\Value\StoreId;
 
 /**
- * @deprecated Should be moved to common-collection
- *
  * @extends ImmutableCollection<array-key, StoreId>
+ * @use StringCollectionTrait<array-key, StoreId>
  */
 final class StoreIds extends ImmutableCollection implements StoreIdsInterface
 {
     use StringCollectionTrait;
 
-    /**
-     * @param StoreId[]|int[] $entries
-     */
+    /** @param StoreId[]|int[] $entries */
     public function __construct(array $entries = [])
     {
         parent::__construct(
@@ -24,8 +21,8 @@ final class StoreIds extends ImmutableCollection implements StoreIdsInterface
                 static function ($entry) {
                     return $entry instanceof StoreId ? $entry : new StoreId($entry);
                 },
-                $entries
-            )
+                $entries,
+            ),
         );
     }
 
@@ -38,9 +35,7 @@ final class StoreIds extends ImmutableCollection implements StoreIdsInterface
         return $this[\array_rand($this->toArray(), 1)];
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function contains($element): bool
     {
         return \in_array($element, $this->getArrayCopy(), false);

--- a/src/Collection/StoreIdsInterface.php
+++ b/src/Collection/StoreIdsInterface.php
@@ -5,16 +5,10 @@ namespace MyOnlineStore\Common\Domain\Collection;
 
 use MyOnlineStore\Common\Domain\Value\StoreId;
 
-/**
- * @method StoreId[] getIterator()
- *
- * @deprecated Should be moved to common-collection
- */
+/** @method StoreId[] getIterator() */
 interface StoreIdsInterface extends ImmutableCollectionInterface
 {
-    /**
-     * @throws \InvalidArgumentException
-     */
+    /** @throws \InvalidArgumentException */
     public function getRandom(): StoreId;
 
     public function unique(): StoreIdsInterface;

--- a/src/Collection/StringCollectionInterface.php
+++ b/src/Collection/StringCollectionInterface.php
@@ -2,13 +2,8 @@
 
 namespace MyOnlineStore\Common\Domain\Collection;
 
-/**
- * @deprecated Should be moved to common-collection
- */
 interface StringCollectionInterface
 {
-    /**
-     * @return string[]
-     */
+    /** @return string[] */
     public function asStrings(): array;
 }

--- a/src/Collection/StringCollectionTrait.php
+++ b/src/Collection/StringCollectionTrait.php
@@ -4,20 +4,17 @@ declare(strict_types=1);
 namespace MyOnlineStore\Common\Domain\Collection;
 
 /**
- * @deprecated Should be moved to common-collection
+ * @template TKey of array-key
+ * @template T
  */
 trait StringCollectionTrait
 {
-    /**
-     * @return string[]
-     */
+    /** @return array<TKey, string> */
     public function asStrings(): array
     {
         return \array_map('strval', $this->toArray());
     }
 
-    /**
-     * @return array
-     */
+    /** @return array<TKey, T> */
     abstract public function toArray();
 }

--- a/src/Exception/Color/InvalidHexColor.php
+++ b/src/Exception/Color/InvalidHexColor.php
@@ -5,23 +5,19 @@ namespace MyOnlineStore\Common\Domain\Exception\Color;
 
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class InvalidHexColor extends InvalidArgument
 {
-    /**
-     * @psalm-pure
-     */
-    public static function withHexColor(string $color, ?\Throwable $previous = null): self
+    /** @psalm-pure */
+    public static function withHexColor(string $color, \Throwable|null $previous = null): self
     {
         return new self(
             \sprintf(
                 'The hexadecimal value "%s" is invalid, requires a # sign and 6 or 3 characters',
-                $color
+                $color,
             ),
             0,
-            $previous
+            $previous,
         );
     }
 }

--- a/src/Exception/Currency/InvalidCurrencyIso.php
+++ b/src/Exception/Currency/InvalidCurrencyIso.php
@@ -5,9 +5,7 @@ namespace MyOnlineStore\Common\Domain\Exception\Currency;
 
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class InvalidCurrencyIso extends InvalidArgument
 {
 }

--- a/src/Exception/Finance/InvalidBic.php
+++ b/src/Exception/Finance/InvalidBic.php
@@ -5,14 +5,10 @@ namespace MyOnlineStore\Common\Domain\Exception\Finance;
 
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class InvalidBic extends InvalidArgument
 {
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function withBic(string $bic): self
     {
         return new self(\sprintf('The provided BIC "%s" is invalid', $bic));

--- a/src/Exception/Finance/InvalidIban.php
+++ b/src/Exception/Finance/InvalidIban.php
@@ -5,9 +5,7 @@ namespace MyOnlineStore\Common\Domain\Exception\Finance;
 
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class InvalidIban extends InvalidArgument
 {
 }

--- a/src/Exception/InvalidArgument.php
+++ b/src/Exception/InvalidArgument.php
@@ -3,9 +3,7 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Exception;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 class InvalidArgument extends \InvalidArgumentException
 {
 }

--- a/src/Exception/LocaleNotFound.php
+++ b/src/Exception/LocaleNotFound.php
@@ -3,9 +3,7 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Exception;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class LocaleNotFound extends NotFoundException
 {
 }

--- a/src/Exception/Mail/InvalidEmailAddress.php
+++ b/src/Exception/Mail/InvalidEmailAddress.php
@@ -5,9 +5,7 @@ namespace MyOnlineStore\Common\Domain\Exception\Mail;
 
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class InvalidEmailAddress extends InvalidArgument
 {
 }

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -3,9 +3,7 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Exception;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 class NotFoundException extends \Exception
 {
 }

--- a/src/Exception/Person/InvalidGender.php
+++ b/src/Exception/Person/InvalidGender.php
@@ -5,9 +5,7 @@ namespace MyOnlineStore\Common\Domain\Exception\Person;
 
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class InvalidGender extends InvalidArgument
 {
 }

--- a/src/Exception/Web/InvalidHostName.php
+++ b/src/Exception/Web/InvalidHostName.php
@@ -3,9 +3,7 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Exception\Web;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class InvalidHostName extends \RuntimeException
 {
 }

--- a/src/Exception/Web/UrlNotFound.php
+++ b/src/Exception/Web/UrlNotFound.php
@@ -5,9 +5,7 @@ namespace MyOnlineStore\Common\Domain\Exception\Web;
 
 use MyOnlineStore\Common\Domain\Exception\NotFoundException;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class UrlNotFound extends NotFoundException
 {
 }

--- a/src/Value/Arithmetic/Amount.php
+++ b/src/Value/Arithmetic/Amount.php
@@ -42,9 +42,7 @@ final class Amount extends Number
         return $this->value->asInteger();
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function asZero(): Amount
     {
         return new self(0);

--- a/src/Value/Arithmetic/Number.php
+++ b/src/Value/Arithmetic/Number.php
@@ -6,9 +6,7 @@ namespace MyOnlineStore\Common\Domain\Value\Arithmetic;
 use Litipk\BigNumbers\Decimal;
 use Litipk\BigNumbers\Errors\BigNumbersError;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 class Number
 {
     /** @var Decimal */
@@ -19,7 +17,7 @@ class Number
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($value, ?int $scale = null)
+    public function __construct($value, int|null $scale = null)
     {
         $this->assignValue($value, $scale);
     }
@@ -29,10 +27,8 @@ class Number
         return (string) $this->value;
     }
 
-    /**
-     * @return static
-     */
-    public function add(Number $operand, ?int $scale = null)
+    /** @return static */
+    public function add(Number $operand, int|null $scale = null)
     {
         $this->assertOperand($operand);
 
@@ -47,7 +43,7 @@ class Number
      *
      * @throws \InvalidArgumentException
      */
-    public function changeValue($value, ?int $scale = null)
+    public function changeValue($value, int|null $scale = null)
     {
         $newMetric = clone $this;
         $newMetric->assignValue($value, $scale);
@@ -55,10 +51,8 @@ class Number
         return $newMetric;
     }
 
-    /**
-     * @return static
-     */
-    public function divideBy(Number $operand, ?int $scale = null)
+    /** @return static */
+    public function divideBy(Number $operand, int|null $scale = null)
     {
         $this->assertOperand($operand);
 
@@ -66,7 +60,7 @@ class Number
         return $this->changeValue($this->value->div($operand->value, $scale), $scale);
     }
 
-    public function equals(Number $operand, ?int $scale = null): bool
+    public function equals(Number $operand, int|null $scale = null): bool
     {
         $this->assertOperand($operand);
 
@@ -74,13 +68,13 @@ class Number
         return $this->value->equals($operand->value, $scale);
     }
 
-    public function isGreaterThan(Number $operand, ?int $scale = null): bool
+    public function isGreaterThan(Number $operand, int|null $scale = null): bool
     {
         /** @psalm-suppress ImpureMethodCall */
         return 1 === $this->value->comp($operand->value, $scale);
     }
 
-    public function isLessThan(Number $operand, ?int $scale = null): bool
+    public function isLessThan(Number $operand, int|null $scale = null): bool
     {
         /** @psalm-suppress ImpureMethodCall */
         return -1 === $this->value->comp($operand->value, $scale);
@@ -92,10 +86,8 @@ class Number
         return $this->value->isZero();
     }
 
-    /**
-     * @return static
-     */
-    public function multiplyBy(Number $operand, ?int $scale = null)
+    /** @return static */
+    public function multiplyBy(Number $operand, int|null $scale = null)
     {
         $this->assertOperand($operand);
 
@@ -103,19 +95,15 @@ class Number
         return $this->changeValue($this->value->mul($operand->value, $scale), $scale);
     }
 
-    /**
-     * @return static
-     */
-    public function powerTo(Number $operand, ?int $scale = null)
+    /** @return static */
+    public function powerTo(Number $operand, int|null $scale = null)
     {
         /** @psalm-suppress ImpureMethodCall */
         return $this->changeValue($this->value->pow($operand->value, $scale));
     }
 
-    /**
-     * @return static
-     */
-    public function subtract(Number $operand, ?int $scale = null)
+    /** @return static */
+    public function subtract(Number $operand, int|null $scale = null)
     {
         $this->assertOperand($operand);
 
@@ -123,9 +111,7 @@ class Number
         return $this->changeValue($this->value->sub($operand->value, $scale), $scale);
     }
 
-    /**
-     * @return static
-     */
+    /** @return static */
     public function toScale(int $scale)
     {
         /** @psalm-suppress ImpureMethodCall */
@@ -142,7 +128,7 @@ class Number
      *
      * @throws \InvalidArgumentException
      */
-    private function assignValue($value, ?int $scale = null): void
+    private function assignValue($value, int|null $scale = null): void
     {
         if ($value instanceof self) {
             $value = $value->value;

--- a/src/Value/Arithmetic/Percentage.php
+++ b/src/Value/Arithmetic/Percentage.php
@@ -13,7 +13,7 @@ use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
  */
 final class Percentage extends Number
 {
-    private function __construct(string $value, ?int $scale = null)
+    private function __construct(string $value, int|null $scale = null)
     {
         parent::__construct($value, $scale);
 
@@ -23,10 +23,8 @@ final class Percentage extends Number
         }
     }
 
-    /**
-     * @psalm-pure
-     */
-    public static function fromString(string $value, ?int $scale = null): self
+    /** @psalm-pure */
+    public static function fromString(string $value, int|null $scale = null): self
     {
         return new self($value, $scale);
     }

--- a/src/Value/Color/HexColor.php
+++ b/src/Value/Color/HexColor.php
@@ -16,7 +16,7 @@ class HexColor
 
     private function __construct(string $value)
     {
-        if (!$this->isValidHexColor($value)) {
+        if (!self::isValidHexColor($value)) {
             throw InvalidHexColor::withHexColor($value);
         }
 
@@ -27,9 +27,7 @@ class HexColor
         $this->value = \strtoupper($value);
     }
 
-    /**
-     * @throws \InvalidArgumentException
-     */
+    /** @throws \InvalidArgumentException */
     public static function fromString(string $value): self
     {
         return new self($value);

--- a/src/Value/Contact/PhoneNumber.php
+++ b/src/Value/Contact/PhoneNumber.php
@@ -10,9 +10,7 @@ use libphonenumber\PhoneNumberType;
 use libphonenumber\PhoneNumberUtil;
 use MyOnlineStore\Common\Domain\Value\RegionCode;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class PhoneNumber
 {
     /** @var PhoneNumberUtil */
@@ -26,7 +24,7 @@ final class PhoneNumber
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($value, ?RegionCode $regionCode = null)
+    public function __construct($value, RegionCode|null $regionCode = null)
     {
         $this->phoneNumberUtil = PhoneNumberUtil::getInstance();
 
@@ -41,7 +39,7 @@ final class PhoneNumber
             throw new \InvalidArgumentException(
                 \sprintf('Invalid phonenumber (%s)', $value),
                 0,
-                $exception
+                $exception,
             );
         }
     }
@@ -61,7 +59,7 @@ final class PhoneNumber
         return 0 === \strcasecmp((string) $this, (string) $comparison);
     }
 
-    public function getCountryCode(): ?int
+    public function getCountryCode(): int|null
     {
         return $this->value->getCountryCode();
     }
@@ -87,7 +85,7 @@ final class PhoneNumber
                 PhoneNumberType::FIXED_LINE,
                 PhoneNumberType::FIXED_LINE_OR_MOBILE,
             ],
-            true
+            true,
         );
     }
 
@@ -100,7 +98,7 @@ final class PhoneNumber
                 PhoneNumberType::MOBILE,
                 PhoneNumberType::FIXED_LINE_OR_MOBILE,
             ],
-            true
+            true,
         );
     }
 

--- a/src/Value/Finance/Bic.php
+++ b/src/Value/Finance/Bic.php
@@ -6,9 +6,7 @@ namespace MyOnlineStore\Common\Domain\Value\Finance;
 use IsoCodes\SwiftBic;
 use MyOnlineStore\Common\Domain\Exception\Finance\InvalidBic;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class Bic
 {
     /** @var string */
@@ -19,9 +17,7 @@ final class Bic
         $this->bic = $bic;
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function fromString(string $bic): self
     {
         $bic = \mb_strtoupper($bic);

--- a/src/Value/Finance/Iban.php
+++ b/src/Value/Finance/Iban.php
@@ -21,9 +21,7 @@ final class Iban
      */
     private $iban;
 
-    /**
-     * @throws InvalidIban
-     */
+    /** @throws InvalidIban */
     public function __construct(string $iban)
     {
         $iban = \mb_strtoupper($iban);

--- a/src/Value/LanguageCode.php
+++ b/src/Value/LanguageCode.php
@@ -40,8 +40,13 @@ final class LanguageCode
         return $this->code === $comparator->code;
     }
 
-    public function __toString(): string
+    public function toString(): string
     {
         return $this->code;
+    }
+
+    public function __toString(): string
+    {
+        return $this->toString();
     }
 }

--- a/src/Value/Locale.php
+++ b/src/Value/Locale.php
@@ -43,9 +43,9 @@ final class Locale
      */
     public static function fromString($string): self
     {
-        if (false === \strpos($string, '_')) {
+        if (!\str_contains($string, '_')) {
             throw new InvalidArgument(
-                \sprintf('Given string "%s" is not a valid string representation of a locale', $string)
+                \sprintf('Given string "%s" is not a valid string representation of a locale', $string),
             );
         }
 
@@ -70,8 +70,13 @@ final class Locale
         return $this->regionCode;
     }
 
-    public function __toString(): string
+    public function toString(): string
     {
         return \sprintf('%s_%s', $this->languageCode, $this->regionCode);
+    }
+
+    public function __toString(): string
+    {
+        return $this->toString();
     }
 }

--- a/src/Value/Location/Address/Street.php
+++ b/src/Value/Location/Address/Street.php
@@ -39,7 +39,7 @@ final class Street
      */
     private $suffix;
 
-    public function __construct(StreetName $name, StreetNumber $number, ?StreetSuffix $suffix = null)
+    public function __construct(StreetName $name, StreetNumber $number, StreetSuffix|null $suffix = null)
     {
         $this->name = $name;
         $this->number = $number;
@@ -58,7 +58,7 @@ final class Street
                 return new self(
                     StreetName::fromString($results['street']),
                     StreetNumber::fromString($results['number']),
-                    $results['suffix'] ? StreetSuffix::fromString($results['suffix']) : null
+                    $results['suffix'] ? StreetSuffix::fromString($results['suffix']) : null,
                 );
             }
         }
@@ -83,7 +83,7 @@ final class Street
         return $this->number;
     }
 
-    public function getSuffix(): ?StreetSuffix
+    public function getSuffix(): StreetSuffix|null
     {
         return $this->suffix ? StreetSuffix::fromString($this->suffix) : null;
     }

--- a/src/Value/Location/Address/StreetSuffix.php
+++ b/src/Value/Location/Address/StreetSuffix.php
@@ -6,9 +6,7 @@ namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class StreetSuffix
 {
     /** @var string */

--- a/src/Value/Location/Address/ZipCode.php
+++ b/src/Value/Location/Address/ZipCode.php
@@ -41,9 +41,7 @@ final class ZipCode
         return new self(\mb_strtoupper($zipCode));
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function asNotAvailable(): self
     {
         return new self(self::NOT_AVAILABLE);

--- a/src/Value/Mail/EmailAddress.php
+++ b/src/Value/Mail/EmailAddress.php
@@ -22,9 +22,7 @@ final class EmailAddress
      */
     private $emailAddress;
 
-    /**
-     * @throws InvalidEmailAddress
-     */
+    /** @throws InvalidEmailAddress */
     public function __construct(string $emailAddress)
     {
         $validator = new EmailValidator();
@@ -42,8 +40,13 @@ final class EmailAddress
         return $this->emailAddress === $comparator->emailAddress;
     }
 
-    public function __toString(): string
+    public function toString(): string
     {
         return $this->emailAddress;
+    }
+
+    public function __toString(): string
+    {
+        return $this->toString();
     }
 }

--- a/src/Value/Monetary/Amount.php
+++ b/src/Value/Monetary/Amount.php
@@ -27,9 +27,7 @@ final class Amount extends Number
         parent::__construct($value, 0);
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function asZero(): Amount
     {
         return new self(0);

--- a/src/Value/Money/Money.php
+++ b/src/Value/Money/Money.php
@@ -33,14 +33,12 @@ final class Money
         $this->currency = $currency;
     }
 
-    /**
-     * @throws \InvalidArgumentException
-     */
+    /** @throws \InvalidArgumentException */
     public function add(self $otherMoney): self
     {
         if (!$this->currency->equals($otherMoney->currency)) {
             throw new \InvalidArgumentException(
-                \sprintf('Cannot mix %s currency with %s', $this->currency, $otherMoney->currency)
+                \sprintf('Cannot mix %s currency with %s', $this->currency, $otherMoney->currency),
             );
         }
 
@@ -63,10 +61,10 @@ final class Money
                 (int) \bcmul(
                     (string) \round((float) $amount, $currency->getMinorUnit()),
                     \sprintf('1%s', \str_repeat('0', $currency->getMinorUnit())),
-                    $currency->getMinorUnit()
-                )
+                    $currency->getMinorUnit(),
+                ),
             ),
-            $currency
+            $currency,
         );
     }
 
@@ -91,7 +89,7 @@ final class Money
         return \bcdiv(
             (string) $this->amount,
             \sprintf('1%s', \str_repeat('0', $this->currency->getMinorUnit())),
-            $this->currency->getMinorUnit()
+            $this->currency->getMinorUnit(),
         );
     }
 }

--- a/src/Value/Money/Price.php
+++ b/src/Value/Money/Price.php
@@ -26,9 +26,7 @@ final class Price
      */
     private $amount;
 
-    /**
-     * @param float|int|string $amount
-     */
+    /** @param float|int|string $amount */
     public function __construct($amount)
     {
         if (!\is_numeric($amount) && '' !== $amount) {
@@ -68,7 +66,7 @@ final class Price
      * add a percentage of the value represented by this Price
      * object and returns a new Price object
      *
-     * @psalm-param numeric-string $percentage
+     * @param numeric-string $percentage
      */
     public function addPercentage(string $percentage, int $scale = self::PRECISION_CALC): self
     {
@@ -79,6 +77,7 @@ final class Price
         return new self($priceWithPercentage);
     }
 
+    /** @param 0|positive-int $roundingMode */
     public function asCents(int $roundingMode = \PHP_ROUND_HALF_EVEN): int
     {
         return (int) \round((float) \bcmul('100.0', $this->amount, self::PRECISION_CALC), 0, $roundingMode);

--- a/src/Value/Person/BirthDate.php
+++ b/src/Value/Person/BirthDate.php
@@ -14,9 +14,7 @@ final class BirthDate
 {
     private const FORMAT = 'Y-m-d';
 
-    /**
-     * @ORM\Column(name="birth_date", type="date_immutable")
-     */
+    /** @ORM\Column(name="birth_date", type="date_immutable") */
     private \DateTimeImmutable $date;
 
     private function __construct(\DateTimeImmutable $date)
@@ -24,9 +22,7 @@ final class BirthDate
         $this->date = $date;
     }
 
-    /**
-     * @psalm-suppress InvalidToString
-     */
+    /** @psalm-suppress InvalidToString */
     public function __toString(): string
     {
         return $this->date->format(self::FORMAT);
@@ -37,30 +33,24 @@ final class BirthDate
         return (string) $this === (string) $comparator;
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function fromDateTime(\DateTimeImmutable $date): self
     {
         return new self($date);
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function fromString(string $date): self
     {
         return self::fromStringWithFormat($date);
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function fromStringWithFormat(
         string $date,
         string $format = self::FORMAT
     ): self {
-        /** @psalm-suppress PossiblyFalseArgument */
+        /** @psalm-suppress ImpureMethodCall, PossiblyFalseArgument */
 
         return new self(\DateTimeImmutable::createFromFormat($format, $date));
     }

--- a/src/Value/Person/Gender.php
+++ b/src/Value/Person/Gender.php
@@ -42,17 +42,13 @@ final class Gender
         return new self($gender);
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function asMale(): self
     {
         return new self(self::MALE);
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function asFemale(): self
     {
         return new self(self::FEMALE);

--- a/src/Value/RegionCode.php
+++ b/src/Value/RegionCode.php
@@ -40,9 +40,7 @@ final class RegionCode
         $this->code = \strtoupper($code);
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function asNL(): self
     {
         return new self('NL');
@@ -53,9 +51,7 @@ final class RegionCode
         return 0 === \strcmp($this->code, $comparator->code);
     }
 
-    /**
-     * @return string returns lowercase value
-     */
+    /** @return string returns lowercase value */
     public function lower(): string
     {
         return \strtolower($this->code);
@@ -94,12 +90,17 @@ final class RegionCode
                 'SI', // Slovenia
                 'SK', // Slovakia
             ],
-            true
+            true,
         );
+    }
+
+    public function toString(): string
+    {
+        return $this->code;
     }
 
     public function __toString(): string
     {
-        return $this->code;
+        return $this->toString();
     }
 }

--- a/src/Value/StoreId.php
+++ b/src/Value/StoreId.php
@@ -3,19 +3,14 @@
 namespace MyOnlineStore\Common\Domain\Value;
 
 use Doctrine\ORM\Mapping as ORM;
-use MyOnlineStore\Common\Domain\Assertion\NumericAssertionTrait;
 
 /**
- * @deprecated Should be removed from common-domain
- *
  * @ORM\Embeddable
  *
  * @psalm-immutable
  */
 final class StoreId
 {
-    use NumericAssertionTrait;
-
     /**
      * @ORM\Column(name="store_id", type="integer")
      *
@@ -23,25 +18,28 @@ final class StoreId
      */
     private $id;
 
-    /**
-     * @param int|string $id
-     */
+    /** @param int|string $id */
     public function __construct($id)
     {
-        if (!$this->assertIsNumeric($id)) {
+        if (!\is_numeric($id)) {
             throw new \InvalidArgumentException(\sprintf('Given ID "%s" is not numeric', $id));
         }
 
         $this->id = $id;
     }
 
-    public function __toString(): string
+    public function equals(self $storeId): bool
+    {
+        return (string) $this->id === (string) $storeId->id;
+    }
+
+    public function toString(): string
     {
         return (string) $this->id;
     }
 
-    public function equals(self $storeId): bool
+    public function __toString(): string
     {
-        return (string) $this->id === (string) $storeId->id;
+        return $this->toString();
     }
 }

--- a/src/Value/Type/AbstractUuid.php
+++ b/src/Value/Type/AbstractUuid.php
@@ -7,9 +7,7 @@ use Ramsey\Uuid\Exception\InvalidUuidStringException;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 abstract class AbstractUuid
 {
     /** @var UuidInterface $uuid */
@@ -20,9 +18,7 @@ abstract class AbstractUuid
         $this->uuid = $uuid;
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function fromBytes(string $bytes): static
     {
         return new static(Uuid::fromBytes($bytes));
@@ -40,17 +36,13 @@ abstract class AbstractUuid
         return new static(Uuid::uuid5($namespace, (string) $numericId));
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function fromString(string $string): static
     {
         return new static(Uuid::fromString($string));
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function generate(): static
     {
         /** @psalm-suppress ImpureMethodCall */

--- a/src/Value/Web/DomainName.php
+++ b/src/Value/Web/DomainName.php
@@ -8,17 +8,13 @@ use Pdp\ResolvedDomainName;
 use Pdp\Rules;
 use Pdp\SyntaxError;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class DomainName
 {
     private ResolvedDomainName $resolvedDomainName;
-    private static ?Rules $rules = null;
+    private static Rules|null $rules = null;
 
-    /**
-     * @throws \InvalidArgumentException
-     */
+    /** @throws \InvalidArgumentException */
     public function __construct(string $domainName)
     {
         $domainName = \trim($domainName);
@@ -30,7 +26,7 @@ final class DomainName
         } catch (SyntaxError $exception) {
             throw new \InvalidArgumentException(
                 \sprintf('Invalid domain given "%s".', $domainName),
-                previous: $exception
+                previous: $exception,
             );
         }
     }
@@ -45,42 +41,32 @@ final class DomainName
         return $this->resolvedDomainName->toString() === $otherDomainName->resolvedDomainName->toString();
     }
 
-    /**
-     * @deprecated Should be extracted to external service
-     */
-    public function getHostName(): ?string
+    /** @deprecated Should be extracted to external service */
+    public function getHostName(): string|null
     {
         return \explode('.', $this->resolvedDomainName->registrableDomain()->toString(), 2)[0] ?? null;
     }
 
-    /**
-     * @deprecated Should be extracted to external service
-     */
+    /** @deprecated Should be extracted to external service */
     public function getRootDomain(): self
     {
         return new self($this->resolvedDomainName->registrableDomain()->toString());
     }
 
-    /**
-     * @deprecated Should be extracted to external service
-     */
+    /** @deprecated Should be extracted to external service */
     public function isRootDomain(): bool
     {
         return $this->resolvedDomainName->registrableDomain()->value() === $this->resolvedDomainName->value();
     }
 
-    /**
-     * @deprecated Should be extracted to external service
-     */
-    public function getSubdomain(): ?string
+    /** @deprecated Should be extracted to external service */
+    public function getSubdomain(): string|null
     {
         return $this->resolvedDomainName->subDomain()->value();
     }
 
-    /**
-     * @deprecated Should be extracted to external service
-     */
-    public function getTld(): ?string
+    /** @deprecated Should be extracted to external service */
+    public function getTld(): string|null
     {
         return $this->resolvedDomainName->suffix()->value();
     }
@@ -14163,7 +14149,7 @@ enterprisecloud.nu
 
 // ===END PRIVATE DOMAINS===
 
-RULES
+RULES,
             );
         }
 

--- a/src/Value/Web/HostName.php
+++ b/src/Value/Web/HostName.php
@@ -3,9 +3,7 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Web;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class HostName
 {
     /** @var string */

--- a/src/Value/Web/IPAddressVersion.php
+++ b/src/Value/Web/IPAddressVersion.php
@@ -3,9 +3,7 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Web;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class IPAddressVersion
 {
     public const IPV4 = 'IPv4';

--- a/src/Value/Web/Url.php
+++ b/src/Value/Web/Url.php
@@ -9,9 +9,7 @@ use League\Uri\Http;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 use Psr\Http\Message\UriInterface as Psr7UriInterface;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class Url implements Psr7UriInterface
 {
     private function __construct(
@@ -82,7 +80,7 @@ final class Url implements Psr7UriInterface
         } catch (SyntaxError $exception) {
             throw new InvalidArgument(
                 \sprintf('Invalid URL "%s" provided', $value),
-                previous: $exception
+                previous: $exception,
             );
         }
 

--- a/src/Value/Web/UrlHost.php
+++ b/src/Value/Web/UrlHost.php
@@ -5,9 +5,7 @@ namespace MyOnlineStore\Common\Domain\Value\Web;
 
 use MyOnlineStore\Common\Domain\Exception\Web\InvalidHostName;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class UrlHost
 {
     /** @var string */
@@ -32,9 +30,7 @@ final class UrlHost
         return $this->hostname;
     }
 
-    /**
-     * @throws \InvalidArgumentException
-     */
+    /** @throws \InvalidArgumentException */
     public function getDomainName(): DomainName
     {
         return new DomainName($this->hostname);

--- a/src/Value/Web/UrlPath.php
+++ b/src/Value/Web/UrlPath.php
@@ -3,9 +3,7 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Web;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class UrlPath
 {
     /** @var string */

--- a/src/Value/Web/UrlPathType.php
+++ b/src/Value/Web/UrlPathType.php
@@ -5,9 +5,7 @@ namespace MyOnlineStore\Common\Domain\Value\Web;
 
 use MyOnlineStore\Common\Domain\Assertion\EnumValueGuardTrait;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class UrlPathType
 {
     use EnumValueGuardTrait;
@@ -26,33 +24,25 @@ final class UrlPathType
         $this->value = $value;
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function asAbsolutePath(): self
     {
         return new self(self::ABSOLUTE_PATH);
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function asAbsoluteUrl(): self
     {
         return new self(self::ABSOLUTE_URL);
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function asNetworkPath(): self
     {
         return new self(self::NETWORK_PATH);
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function asRelativePath(): self
     {
         return new self(self::RELATIVE_PATH);
@@ -68,9 +58,7 @@ final class UrlPathType
         return $this->value;
     }
 
-    /**
-     * @return int[]
-     */
+    /** @return int[] */
     protected function getValidValues(): array
     {
         return [

--- a/src/Value/Web/ViewPort.php
+++ b/src/Value/Web/ViewPort.php
@@ -43,25 +43,19 @@ final class ViewPort
         return $this->value;
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function asSmall(): self
     {
         return new self(self::SMALL);
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function asMedium(): self
     {
         return new self(self::MEDIUM);
     }
 
-    /**
-     * @psalm-pure
-     */
+    /** @psalm-pure */
     public static function asLarge(): self
     {
         return new self(self::LARGE);
@@ -92,9 +86,7 @@ final class ViewPort
         return [self::SMALL, self::MEDIUM, self::LARGE];
     }
 
-    /**
-     * @return string[]
-     */
+    /** @return string[] */
     protected function getValidValues(): array
     {
         return self::getAvailableViewPorts();

--- a/tests/Collection/MutableCollectionTest.php
+++ b/tests/Collection/MutableCollectionTest.php
@@ -40,8 +40,8 @@ final class MutableCollectionTest extends TestCase
                     static function (\Throwable $exception) {
                         return 'foo' === $exception->getMessage();
                     },
-                ]
-            )
+                ],
+            ),
         );
 
         self::assertFalse(
@@ -51,8 +51,8 @@ final class MutableCollectionTest extends TestCase
                     static function (\Throwable $exception) {
                         return 'qux' === $exception->getMessage();
                     },
-                ]
-            )
+                ],
+            ),
         );
     }
 
@@ -69,7 +69,7 @@ final class MutableCollectionTest extends TestCase
         $test->each(
             static function (\Iterator $item): void {
                 $item->next();
-            }
+            },
         );
     }
 
@@ -101,9 +101,7 @@ final class MutableCollectionTest extends TestCase
 
         $extendedClass = new class ([$element1, $element2]) extends MutableCollection
         {
-            /**
-             * @return static
-             */
+            /** @return static */
             public function filter(\Closure $closure)
             {
                 return parent::filter($closure);
@@ -115,8 +113,8 @@ final class MutableCollectionTest extends TestCase
             $extendedClass->filter(
                 static function (\stdClass $element) {
                     return $element->isFoobar();
-                }
-            )->toArray()
+                },
+            )->toArray(),
         );
     }
 
@@ -153,8 +151,8 @@ final class MutableCollectionTest extends TestCase
             $extendedClass->firstHaving(
                 static function (\stdClass $element) {
                     return $element->isFoobar();
-                }
-            )
+                },
+            ),
         );
     }
 
@@ -182,7 +180,7 @@ final class MutableCollectionTest extends TestCase
         $extendedClass->firstHaving(
             static function (\stdClass $element) {
                 return $element->isFoobar();
-            }
+            },
         );
     }
 
@@ -215,9 +213,7 @@ final class MutableCollectionTest extends TestCase
 
         $extendedClass = new class ([$element1, $element2]) extends MutableCollection
         {
-            /**
-             * @return static
-             */
+            /** @return static */
             public function map(\Closure $closure)
             {
                 return parent::map($closure);
@@ -229,8 +225,8 @@ final class MutableCollectionTest extends TestCase
             $extendedClass->map(
                 static function (\stdClass $element) {
                     return $element;
-                }
-            )->toArray()
+                },
+            )->toArray(),
         );
     }
 

--- a/tests/Collection/RegionCodeCollectionTest.php
+++ b/tests/Collection/RegionCodeCollectionTest.php
@@ -25,9 +25,9 @@ final class RegionCodeCollectionTest extends TestCase
                     new RegionCode('NL'),
                     new RegionCode('BE'),
                     new RegionCode('DE'),
-                ]
+                ],
             ),
-            RegionCodeCollection::fromStrings(['NL', 'BE', 'DE'])
+            RegionCodeCollection::fromStrings(['NL', 'BE', 'DE']),
         );
     }
 
@@ -41,7 +41,7 @@ final class RegionCodeCollectionTest extends TestCase
                 new RegionCode('NL'),
                 new RegionCode('DE'),
                 'foo',
-            ]
+            ],
         );
 
         self::assertEquals(
@@ -50,9 +50,9 @@ final class RegionCodeCollectionTest extends TestCase
                     new RegionCode('NL'),
                     new RegionCode('BE'),
                     new RegionCode('DE'),
-                ]
+                ],
             ),
-            $collection->unique()
+            $collection->unique(),
         );
     }
 }

--- a/tests/Collection/StoreIdsTest.php
+++ b/tests/Collection/StoreIdsTest.php
@@ -13,7 +13,7 @@ final class StoreIdsTest extends TestCase
     {
         self::assertEquals(
             new StoreIds([new StoreId(123), new StoreId(456), new StoreId(789)]),
-            new StoreIds([new StoreId(123), '456', 789])
+            new StoreIds([new StoreId(123), '456', 789]),
         );
     }
 
@@ -53,12 +53,12 @@ final class StoreIdsTest extends TestCase
                 $storeId2,
                 $storeId3,
                 $storeId3,
-            ]
+            ],
         );
 
         self::assertEquals(
             new StoreIds([0 => $storeId1, 2 => $storeId2, 3 => $storeId3]),
-            $collection->unique()
+            $collection->unique(),
         );
     }
 }

--- a/tests/Exception/Color/InvalidHexColorTest.php
+++ b/tests/Exception/Color/InvalidHexColorTest.php
@@ -12,7 +12,7 @@ final class InvalidHexColorTest extends TestCase
     {
         $exception = InvalidHexColor::withHexColor(
             'foobar',
-            $previous = $this->createMock(\Throwable::class)
+            $previous = $this->createMock(\Throwable::class),
         );
 
         self::assertStringContainsString('foobar', $exception->getMessage());

--- a/tests/Value/Color/HexColorTest.php
+++ b/tests/Value/Color/HexColorTest.php
@@ -9,9 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class HexColorTest extends TestCase
 {
-    /**
-     * @return iterable<array{string}>
-     */
+    /** @return iterable<array{string}> */
     public function invalidStringProvider(): iterable
     {
         yield ['#'];
@@ -40,9 +38,7 @@ final class HexColorTest extends TestCase
         self::assertEquals('#112233', HexColor::fromString('#123')->toString());
     }
 
-    /**
-     * @dataProvider invalidStringProvider
-     */
+    /** @dataProvider invalidStringProvider */
     public function testInvalidStringValues(string $value): void
     {
         $this->expectException(InvalidHexColor::class);

--- a/tests/Value/Contact/PhoneNumberTest.php
+++ b/tests/Value/Contact/PhoneNumberTest.php
@@ -9,9 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
-    /**
-     * @return string[][]
-     */
+    /** @return string[][] */
     public function getInvalidStringValues(): array
     {
         return [
@@ -22,9 +20,7 @@ final class PhoneNumberTest extends TestCase
         ];
     }
 
-    /**
-     * @return string[][]
-     */
+    /** @return string[][] */
     public function getValidStringValues(): array
     {
         return [
@@ -37,9 +33,7 @@ final class PhoneNumberTest extends TestCase
         ];
     }
 
-    /**
-     * @return mixed[][]
-     */
+    /** @return mixed[][] */
     public function shortInternationalFormatProvider(): array
     {
         return [
@@ -53,9 +47,7 @@ final class PhoneNumberTest extends TestCase
         ];
     }
 
-    /**
-     * @return mixed[][]
-     */
+    /** @return mixed[][] */
     public function equalPhoneNumberProvider(): array
     {
         return [
@@ -67,9 +59,7 @@ final class PhoneNumberTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider equalPhoneNumberProvider
-     */
+    /** @dataProvider equalPhoneNumberProvider */
     public function testEqualsWillReturnFormatterEquality(
         bool $expectedResult,
         PhoneNumber $phoneNumber,
@@ -105,17 +95,13 @@ final class PhoneNumberTest extends TestCase
         self::assertEquals('+44882315726', (string) $phoneNumber->withRegionCode(new RegionCode('GB')));
     }
 
-    /**
-     * @dataProvider shortInternationalFormatProvider
-     */
+    /** @dataProvider shortInternationalFormatProvider */
     public function testShortInternationalFormat(string $expectedFormat, PhoneNumber $phoneNumber): void
     {
         self::assertEquals($expectedFormat, $phoneNumber->getShortInternationalFormat());
     }
 
-    /**
-     * @dataProvider getInvalidStringValues
-     */
+    /** @dataProvider getInvalidStringValues */
     public function testInvalidStringValues(string $value): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -149,9 +135,7 @@ final class PhoneNumberTest extends TestCase
         self::assertEquals($phoneNumber->getShortInternationalFormat(), (string) $phoneNumber);
     }
 
-    /**
-     * @dataProvider getValidStringValues
-     */
+    /** @dataProvider getValidStringValues */
     public function testValidStringValues(string $value): void
     {
         self::assertInstanceOf(PhoneNumber::class, new PhoneNumber($value));

--- a/tests/Value/LanguageCodeTest.php
+++ b/tests/Value/LanguageCodeTest.php
@@ -9,9 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class LanguageCodeTest extends TestCase
 {
-    /**
-     * @dataProvider invalidArgumentProvider
-     */
+    /** @dataProvider invalidArgumentProvider */
     public function testInvalidTypes(string $argument): void
     {
         $this->expectException(InvalidArgument::class);
@@ -31,9 +29,7 @@ final class LanguageCodeTest extends TestCase
         self::assertFalse((new LanguageCode('nl'))->equals(new LanguageCode('en')));
     }
 
-    /**
-     * @return string[][]
-     */
+    /** @return string[][] */
     public function invalidArgumentProvider(): array
     {
         return [

--- a/tests/Value/LocaleTest.php
+++ b/tests/Value/LocaleTest.php
@@ -62,9 +62,7 @@ final class LocaleTest extends TestCase
         self::assertEquals(new RegionCode('DE'), Locale::fromString('de_DE')->regionCode());
     }
 
-    /**
-     * @return string[][]
-     */
+    /** @return string[][] */
     public function invalidArgumentProvider(): array
     {
         return [

--- a/tests/Value/Location/Address/CityTest.php
+++ b/tests/Value/Location/Address/CityTest.php
@@ -23,9 +23,7 @@ final class CityTest extends TestCase
         yield ["\t "];
     }
 
-    /**
-     * @dataProvider emptyDataProvider
-     */
+    /** @dataProvider emptyDataProvider */
     public function testEmpty(string $empty): void
     {
         $this->expectException(InvalidArgument::class);

--- a/tests/Value/Location/Address/StreetNameTest.php
+++ b/tests/Value/Location/Address/StreetNameTest.php
@@ -24,9 +24,7 @@ final class StreetNameTest extends TestCase
         yield ["\t "];
     }
 
-    /**
-     * @dataProvider emptyDataProvider
-     */
+    /** @dataProvider emptyDataProvider */
     public function testEmpty(string $empty): void
     {
         $this->expectException(InvalidArgument::class);

--- a/tests/Value/Location/Address/StreetNumberTest.php
+++ b/tests/Value/Location/Address/StreetNumberTest.php
@@ -24,9 +24,7 @@ final class StreetNumberTest extends TestCase
         yield ["\t "];
     }
 
-    /**
-     * @dataProvider emptyDataProvider
-     */
+    /** @dataProvider emptyDataProvider */
     public function testEmpty(string $empty): void
     {
         $this->expectException(InvalidArgument::class);

--- a/tests/Value/Location/Address/StreetSuffixTest.php
+++ b/tests/Value/Location/Address/StreetSuffixTest.php
@@ -24,9 +24,7 @@ final class StreetSuffixTest extends TestCase
         yield ["\t "];
     }
 
-    /**
-     * @dataProvider emptyDataProvider
-     */
+    /** @dataProvider emptyDataProvider */
     public function testEmpty(string $empty): void
     {
         $this->expectException(InvalidArgument::class);

--- a/tests/Value/Location/Address/StreetTest.php
+++ b/tests/Value/Location/Address/StreetTest.php
@@ -33,7 +33,7 @@ final class StreetTest extends TestCase
         $street = new Street(
             StreetName::fromString('foo'),
             StreetNumber::fromString('12a'),
-            StreetSuffix::fromString('bar')
+            StreetSuffix::fromString('bar'),
         );
 
         self::assertTrue(
@@ -41,36 +41,36 @@ final class StreetTest extends TestCase
                 new Street(
                     StreetName::fromString('foo'),
                     StreetNumber::fromString('12a'),
-                    StreetSuffix::fromString('bar')
-                )
-            )
+                    StreetSuffix::fromString('bar'),
+                ),
+            ),
         );
         self::assertFalse(
             $street->equals(
                 new Street(
                     StreetName::fromString('bar'),
                     StreetNumber::fromString('12a'),
-                    StreetSuffix::fromString('bar')
-                )
-            )
+                    StreetSuffix::fromString('bar'),
+                ),
+            ),
         );
         self::assertFalse(
             $street->equals(
                 new Street(
                     StreetName::fromString('foo'),
                     StreetNumber::fromString('12b'),
-                    StreetSuffix::fromString('bar')
-                )
-            )
+                    StreetSuffix::fromString('bar'),
+                ),
+            ),
         );
         self::assertFalse(
             $street->equals(
                 new Street(
                     StreetName::fromString('foo'),
                     StreetNumber::fromString('12a'),
-                    StreetSuffix::fromString('foo')
-                )
-            )
+                    StreetSuffix::fromString('foo'),
+                ),
+            ),
         );
         self::assertFalse($street->equals(new Street(StreetName::fromString('foo'), StreetNumber::fromString('12a'))));
 
@@ -84,25 +84,23 @@ final class StreetTest extends TestCase
                 new Street(
                     StreetName::fromString('foo'),
                     StreetNumber::fromString('12a'),
-                    StreetSuffix::fromString('foo')
-                )
-            )
+                    StreetSuffix::fromString('foo'),
+                ),
+            ),
         );
     }
 
-    /**
-     * @dataProvider dataFromSingleLine
-     */
-    public function testFromSingleLine(string $line, string $street, string $number, ?string $suffix): void
+    /** @dataProvider dataFromSingleLine */
+    public function testFromSingleLine(string $line, string $street, string $number, string|null $suffix): void
     {
         self::assertTrue(
             Street::fromSingleLine($line)->equals(
                 new Street(
                     StreetName::fromString($street),
                     StreetNumber::fromString($number),
-                    null !== $suffix ? StreetSuffix::fromString($suffix) : null
-                )
-            )
+                    null !== $suffix ? StreetSuffix::fromString($suffix) : null,
+                ),
+            ),
         );
     }
 
@@ -117,7 +115,7 @@ final class StreetTest extends TestCase
         $street = new Street(
             $name = StreetName::fromString('foo'),
             $number = StreetNumber::fromString('12a'),
-            $suffix = StreetSuffix::fromString('bar')
+            $suffix = StreetSuffix::fromString('bar'),
         );
 
         self::assertSame($name, $street->getName());
@@ -130,7 +128,7 @@ final class StreetTest extends TestCase
     {
         $street = new Street(
             $name = StreetName::fromString('foo'),
-            $number = StreetNumber::fromString('12a')
+            $number = StreetNumber::fromString('12a'),
         );
 
         self::assertSame($name, $street->getName());

--- a/tests/Value/Money/CurrencyIsoTest.php
+++ b/tests/Value/Money/CurrencyIsoTest.php
@@ -25,17 +25,15 @@ final class CurrencyIsoTest extends TestCase
     {
         self::assertTrue(
             CurrencyIso::fromString('OMR')->equals(
-                CurrencyIso::fromString('OMR')
-            )
+                CurrencyIso::fromString('OMR'),
+            ),
         );
         self::assertFalse(CurrencyIso::fromString('OMR')->equals(
-            CurrencyIso::fromString('EUR')
+            CurrencyIso::fromString('EUR'),
         ));
     }
 
-    /**
-     * @dataProvider invalidArgumentProvider
-     */
+    /** @dataProvider invalidArgumentProvider */
     public function testInvalidTypes(string $argument): void
     {
         $this->expectException(InvalidCurrencyIso::class);
@@ -57,9 +55,7 @@ final class CurrencyIsoTest extends TestCase
         self::assertEquals('JPY', (string) CurrencyIso::fromString('JPY'));
     }
 
-    /**
-     * @return string[][]
-     */
+    /** @return string[][] */
     public function invalidArgumentProvider(): array
     {
         return [

--- a/tests/Value/Money/MoneyTest.php
+++ b/tests/Value/Money/MoneyTest.php
@@ -10,9 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 final class MoneyTest extends TestCase
 {
-    /**
-     * @return mixed[]
-     */
+    /** @return mixed[] */
     public function fractionedArgumentProvider(): array
     {
         return [
@@ -86,9 +84,7 @@ final class MoneyTest extends TestCase
         self::assertSame($currency, $money->getCurrency());
     }
 
-    /**
-     * @return mixed[]
-     */
+    /** @return mixed[] */
     public function wholeArgumentProvider(): array
     {
         return [

--- a/tests/Value/Money/PriceTest.php
+++ b/tests/Value/Money/PriceTest.php
@@ -22,7 +22,7 @@ final class PriceTest extends TestCase
         self::assertSame('2.00', (new Price('1'))->add(new Price('1'), Price::PRECISION_DISPLAY)->getAmount());
         self::assertSame(
             '12425.46',
-            (new Price('1.23432423'))->add(new Price('12424.234243'), Price::PRECISION_DISPLAY)->getAmount()
+            (new Price('1.23432423'))->add(new Price('12424.234243'), Price::PRECISION_DISPLAY)->getAmount(),
         );
     }
 

--- a/tests/Value/Person/BirthDateTest.php
+++ b/tests/Value/Person/BirthDateTest.php
@@ -15,7 +15,7 @@ final class BirthDateTest extends TestCase
 
         self::assertEquals(
             \DateTimeImmutable::createFromFormat('Y-m-d', $date),
-            $birthDate->getDate()
+            $birthDate->getDate(),
         );
         self::assertSame($date, (string) $birthDate);
     }
@@ -27,7 +27,7 @@ final class BirthDateTest extends TestCase
 
         self::assertEquals(
             \DateTimeImmutable::createFromFormat('d-m-Y', $date),
-            $birthDate->getDate()
+            $birthDate->getDate(),
         );
         self::assertSame('2019-10-18', (string) $birthDate);
     }

--- a/tests/Value/Person/Name/FirstNameTest.php
+++ b/tests/Value/Person/Name/FirstNameTest.php
@@ -23,9 +23,7 @@ final class FirstNameTest extends TestCase
         yield ["\t "];
     }
 
-    /**
-     * @dataProvider emptyDataProvider
-     */
+    /** @dataProvider emptyDataProvider */
     public function testEmpty(string $empty): void
     {
         $this->expectException(InvalidArgument::class);

--- a/tests/Value/Person/Name/LastNameTest.php
+++ b/tests/Value/Person/Name/LastNameTest.php
@@ -23,9 +23,7 @@ final class LastNameTest extends TestCase
         yield ["\t "];
     }
 
-    /**
-     * @dataProvider emptyDataProvider
-     */
+    /** @dataProvider emptyDataProvider */
     public function testEmpty(string $empty): void
     {
         $this->expectException(InvalidArgument::class);

--- a/tests/Value/Person/NameTest.php
+++ b/tests/Value/Person/NameTest.php
@@ -14,7 +14,7 @@ final class NameTest extends TestCase
     {
         $name = new Name(
             $firstname = FirstName::fromString('foo'),
-            $lastname = LastName::fromString('bar')
+            $lastname = LastName::fromString('bar'),
         );
 
         self::assertSame($firstname, $name->getFirstName());

--- a/tests/Value/RegionCodeTest.php
+++ b/tests/Value/RegionCodeTest.php
@@ -16,10 +16,8 @@ final class RegionCodeTest extends TestCase
         self::assertFalse($regionCode->equals(new RegionCode('DE')));
     }
 
-    /**
-     * @dataProvider invalidArgumentProvider
-     */
-    public function testInvalidTypes(?string $argument): void
+    /** @dataProvider invalidArgumentProvider */
+    public function testInvalidTypes(string|null $argument): void
     {
         $this->expectException(InvalidArgument::class);
         new RegionCode($argument);
@@ -39,9 +37,7 @@ final class RegionCodeTest extends TestCase
         self::assertEquals('de', (new RegionCode('DE'))->lower());
     }
 
-    /**
-     * @return string[][]|null[][]
-     */
+    /** @return string[][]|null[][] */
     public function invalidArgumentProvider(): array
     {
         return [
@@ -52,9 +48,7 @@ final class RegionCodeTest extends TestCase
         ];
     }
 
-    /**
-     * @return \Generator<array{RegionCode, bool}>
-     */
+    /** @return \Generator<array{RegionCode, bool}> */
     public function isEuRegionProvider(): \Generator
     {
         yield [new RegionCode('AT'), true];
@@ -89,9 +83,7 @@ final class RegionCodeTest extends TestCase
         yield [new RegionCode('GB'), false];
     }
 
-    /**
-     * @dataProvider isEuRegionProvider
-     */
+    /** @dataProvider isEuRegionProvider */
     public function testIsEuRegion(RegionCode $regionCode, bool $expected): void
     {
         self::assertEquals($expected, $regionCode->isEuRegion());

--- a/tests/Value/Type/AbstractUuidTest.php
+++ b/tests/Value/Type/AbstractUuidTest.php
@@ -16,7 +16,7 @@ final class AbstractUuidTest extends TestCase
 
         self::assertEquals(
             $uuid->getBytes(),
-            UuidStub::fromBytes($uuid->getBytes())->bytes()
+            UuidStub::fromBytes($uuid->getBytes())->bytes(),
         );
     }
 
@@ -24,7 +24,7 @@ final class AbstractUuidTest extends TestCase
     {
         self::assertEquals(
             '3e5c88c3-8369-4404-8828-6a3927533387',
-            (string) UuidStub::fromString('3e5c88c3-8369-4404-8828-6a3927533387')
+            (string) UuidStub::fromString('3e5c88c3-8369-4404-8828-6a3927533387'),
         );
     }
 

--- a/tests/Value/Web/DomainNameTest.php
+++ b/tests/Value/Web/DomainNameTest.php
@@ -25,9 +25,7 @@ final class DomainNameTest extends TestCase
         new DomainName($value);
     }
 
-    /**
-     * @dataProvider getValidStringValues
-     */
+    /** @dataProvider getValidStringValues */
     public function testValidStringValues(string $value): void
     {
         self::assertInstanceOf(DomainName::class, new DomainName($value));
@@ -38,7 +36,7 @@ final class DomainNameTest extends TestCase
         self::assertEquals('www.domain.org', (string) DomainName::createSubDomain(new DomainName('domain.org'), 'www'));
         self::assertEquals(
             'www.test.domain.org',
-            (string) DomainName::createSubDomain(new DomainName('test.domain.org'), 'www')
+            (string) DomainName::createSubDomain(new DomainName('test.domain.org'), 'www'),
         );
     }
 
@@ -73,9 +71,7 @@ final class DomainNameTest extends TestCase
         self::assertEquals('mijnwebwinkel', (new DomainName('www.shop.mijnwebwinkel.co.uk'))->getHostName());
     }
 
-    /**
-     * @return string[][]
-     */
+    /** @return string[][] */
     public function getInvalidStringValues(): array
     {
         return [
@@ -83,9 +79,7 @@ final class DomainNameTest extends TestCase
         ];
     }
 
-    /**
-     * @return string[][]
-     */
+    /** @return string[][] */
     public function getValidStringValues(): array
     {
         return [

--- a/tests/Value/Web/HostNameTest.php
+++ b/tests/Value/Web/HostNameTest.php
@@ -8,17 +8,13 @@ use PHPUnit\Framework\TestCase;
 
 final class HostNameTest extends TestCase
 {
-    /**
-     * @dataProvider providerValidHostNames
-     */
+    /** @dataProvider providerValidHostNames */
     public function testValidHostNames(string $hostname): void
     {
         self::assertEquals($hostname, (string) new HostName($hostname));
     }
 
-    /**
-     * @dataProvider providerInvalidHostNames
-     */
+    /** @dataProvider providerInvalidHostNames */
     public function testInvalidHostNames(string $hostname): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -26,9 +22,7 @@ final class HostNameTest extends TestCase
         new HostName($hostname);
     }
 
-    /**
-     * @return string[][]
-     */
+    /** @return string[][] */
     public function providerInvalidHostNames(): array
     {
         return [
@@ -39,9 +33,7 @@ final class HostNameTest extends TestCase
         ];
     }
 
-    /**
-     * @return string[][]
-     */
+    /** @return string[][] */
     public function providerValidHostNames(): array
     {
         return [

--- a/tests/Value/Web/UrlHostTest.php
+++ b/tests/Value/Web/UrlHostTest.php
@@ -10,17 +10,13 @@ use PHPUnit\Framework\TestCase;
 
 class UrlHostTest extends TestCase
 {
-    /**
-     * @dataProvider providerValidHostUrls
-     */
+    /** @dataProvider providerValidHostUrls */
     public function testValidUrlHosts(string $hostname): void
     {
         self::assertEquals($hostname, (string) new UrlHost($hostname));
     }
 
-    /**
-     * @dataProvider provider
-     */
+    /** @dataProvider provider */
     public function testInvalidUrlHost(string $hostname): void
     {
         $this->expectException(InvalidHostName::class);
@@ -33,9 +29,7 @@ class UrlHostTest extends TestCase
         self::assertEquals(new DomainName((string) $urlHost), $urlHost->getDomainName());
     }
 
-    /**
-     * @dataProvider providerValidHostUrls
-     */
+    /** @dataProvider providerValidHostUrls */
     public function testInValidDomainName(string $hostname): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -44,17 +38,13 @@ class UrlHostTest extends TestCase
         $urlHost->getDomainName();
     }
 
-    /**
-     * @dataProvider providerValidDomains
-     */
+    /** @dataProvider providerValidDomains */
     public function testValidDomainsFromDomainName(string $domainName): void
     {
         self::assertEquals($domainName, (string) UrlHost::fromDomainName(new DomainName($domainName)));
     }
 
-    /**
-     * @dataProvider providerValidHostUrls
-     */
+    /** @dataProvider providerValidHostUrls */
     public function testInvalidDomainsFromDomainName(string $domainName): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -62,9 +52,7 @@ class UrlHostTest extends TestCase
         self::assertEquals($domainName, (string) UrlHost::fromDomainName(new DomainName($domainName)));
     }
 
-    /**
-     * @return string[][]
-     */
+    /** @return string[][] */
     public function provider(): array
     {
         return [
@@ -75,9 +63,7 @@ class UrlHostTest extends TestCase
         ];
     }
 
-    /**
-     * @return string[][]
-     */
+    /** @return string[][] */
     public function providerValidHostUrls(): array
     {
         return [
@@ -87,9 +73,7 @@ class UrlHostTest extends TestCase
         ];
     }
 
-    /**
-     * @return string[][]
-     */
+    /** @return string[][] */
     public function providerValidDomains(): array
     {
         return [

--- a/tests/Value/Web/UrlTest.php
+++ b/tests/Value/Web/UrlTest.php
@@ -9,9 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class UrlTest extends TestCase
 {
-    /**
-     * @return string[][]
-     */
+    /** @return string[][] */
     public function validUrlDataProvider(): array
     {
         return [
@@ -21,17 +19,13 @@ final class UrlTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider validUrlDataProvider
-     */
+    /** @dataProvider validUrlDataProvider */
     public function testFromStringWillParseStringCorrectly(string $input): void
     {
         self::assertEquals((string) Uri::createFromString($input), (string) Url::fromString($input));
     }
 
-    /**
-     * @return string[][]
-     */
+    /** @return string[][] */
     public function invalidUrlDataProvider(): array
     {
         return [
@@ -40,9 +34,7 @@ final class UrlTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidUrlDataProvider
-     */
+    /** @dataProvider invalidUrlDataProvider */
     public function testFromStringWillThrowExceptionForMalformedUrls(string $input): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -60,19 +52,15 @@ final class UrlTest extends TestCase
         self::assertTrue(Url::createFromString('https://api.host.com:8080/api-route?token=foo#bar')->equals($otherUrl));
     }
 
-    /**
-     * @dataProvider invalidEqualUrlProvider
-     */
+    /** @dataProvider invalidEqualUrlProvider */
     public function testEqualsWillReturnFalseIfObjectDoesNotMatch(Url $otherUrl): void
     {
         self::assertFalse(
-            Url::createFromString('https://api.host.com:8080/api-route?token=foo#bar')->equals($otherUrl)
+            Url::createFromString('https://api.host.com:8080/api-route?token=foo#bar')->equals($otherUrl),
         );
     }
 
-    /**
-     * @return Url[][]
-     */
+    /** @return Url[][] */
     public function invalidEqualUrlProvider(): array
     {
         return [

--- a/tests/benchmarks/Value/LocaleBench.php
+++ b/tests/benchmarks/Value/LocaleBench.php
@@ -8,9 +8,7 @@ use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
 use PhpBench\Benchmark\Metadata\Annotations\Iterations;
 use PhpBench\Benchmark\Metadata\Annotations\Revs;
 
-/**
- * @BeforeMethods({"init"})
- */
+/** @BeforeMethods({"init"}) */
 final class LocaleBench
 {
     /** @var Locale */

--- a/tests/benchmarks/Value/Web/DomainNameBench.php
+++ b/tests/benchmarks/Value/Web/DomainNameBench.php
@@ -7,9 +7,7 @@ use MyOnlineStore\Common\Domain\Value\Web\DomainName;
 use PhpBench\Benchmark\Metadata\Annotations\Iterations;
 use PhpBench\Benchmark\Metadata\Annotations\Revs;
 
-/**
- * @BeforeMethods({"init"})
- */
+/** @BeforeMethods({"init"}) */
 final class DomainNameBench
 {
     /** @var DomainName */


### PR DESCRIPTION
For details see https://psalm.dev/docs/annotating_code/adding_assertions/#asserting-return-values-of-methods

Also bumped the CS and removed `@deprecation` annotations on collections, because they won't be moved to common collection.