### PR TITLE
chore: Improve typing information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ vendor
 composer.lock
 phpunit.xml
 .phpcs-cache
+.phpunit.cache
 .phpunit.result.cache
+rector.php

--- a/composer.json
+++ b/composer.json
@@ -40,9 +40,9 @@
         "doctrine/orm": "^2.13",
         "myonlinestore/coding-standard": "^4.0",
         "phpbench/phpbench": "^1.2",
-        "phpunit/phpunit": "^9.5",
-        "psalm/plugin-phpunit": "^0.17",
+        "phpunit/phpunit": "^10.0",
+        "psalm/plugin-phpunit": "^0.18",
         "symfony/phpunit-bridge": "^6.1",
-        "vimeo/psalm": "^4.29"
+        "vimeo/psalm": "^5.6"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,8 +2,9 @@
 
 <phpunit bootstrap="vendor/autoload.php"
          colors="true"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
 >
     <coverage includeUncoveredFiles="false">
         <include>
@@ -13,20 +14,6 @@
             <file>src/Assertion/Assert.php</file>
         </exclude>
     </coverage>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
-            <arguments>
-                <array>
-                    <!-- set this option to 0 to disable the DebugClassLoader integration -->
-                    <!-- this will remove the 'class X might add return type Y' messages -->
-                    <element key="debug-class-loader">
-                        <integer>0</integer>
-                    </element>
-                </array>
-            </arguments>
-        </listener>
-    </listeners>
 
     <testsuites>
         <testsuite name="Test Suite">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,116 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.24.0@06dd975cb55d36af80f242561738f16c5f58264f">
-  <file src="src/Assertion/EnumValueGuardTrait.php">
-    <InvalidScalarArgument occurrences="1">
-      <code>$value</code>
-    </InvalidScalarArgument>
-  </file>
-  <file src="src/Collection/ImmutableCollection.php">
-    <DeprecatedClass occurrences="1">
-      <code>MutableCollection</code>
-    </DeprecatedClass>
-    <DeprecatedInterface occurrences="1">
-      <code>ImmutableCollection</code>
-    </DeprecatedInterface>
-  </file>
+<files psalm-version="5.6.0@e784128902dfe01d489c4123d69918a9f3c1eac5">
   <file src="src/Collection/ImmutableCollectionInterface.php">
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>each</code>
     </MissingReturnType>
   </file>
   <file src="src/Collection/MutableCollection.php">
-    <DeprecatedClass occurrences="1">
-      <code>ImmutableCollectionInterface</code>
-    </DeprecatedClass>
-    <DeprecatedInterface occurrences="1">
-      <code>MutableCollection</code>
-    </DeprecatedInterface>
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>each</code>
     </MissingReturnType>
-    <UnsafeInstantiation occurrences="3">
+    <UnsafeInstantiation>
       <code>new static(\array_filter($this-&gt;toArray(), $closure))</code>
       <code>new static(\array_map($closure, $this-&gt;toArray()))</code>
       <code>new static(\array_values($this-&gt;toArray()))</code>
     </UnsafeInstantiation>
   </file>
-  <file src="src/Collection/RegionCodeCollection.php">
-    <DeprecatedClass occurrences="4">
-      <code>ImmutableCollection</code>
-      <code>RegionCodeCollectionInterface</code>
-      <code>RegionCodeCollectionInterface</code>
-    </DeprecatedClass>
-    <DeprecatedInterface occurrences="1">
-      <code>RegionCodeCollection</code>
-    </DeprecatedInterface>
-    <DeprecatedTrait occurrences="1">
-      <code>StringCollectionTrait</code>
-    </DeprecatedTrait>
-  </file>
   <file src="src/Collection/RegionCodeCollectionInterface.php">
-    <LessSpecificImplementedReturnType occurrences="1">
+    <LessSpecificImplementedReturnType>
       <code>RegionCodeCollectionInterface</code>
     </LessSpecificImplementedReturnType>
   </file>
-  <file src="src/Collection/StoreIds.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$this-&gt;toArray()</code>
-    </ArgumentTypeCoercion>
-    <DeprecatedClass occurrences="7">
-      <code>ImmutableCollection</code>
-      <code>StoreId</code>
-      <code>StoreId[]|int[]</code>
-      <code>StoreIds</code>
-      <code>StoreIdsInterface</code>
-      <code>new StoreId($entry)</code>
-    </DeprecatedClass>
-    <DeprecatedInterface occurrences="1">
-      <code>StoreIds</code>
-    </DeprecatedInterface>
-    <DeprecatedTrait occurrences="1">
-      <code>StringCollectionTrait</code>
-    </DeprecatedTrait>
-  </file>
-  <file src="src/Collection/StoreIdsInterface.php">
-    <DeprecatedClass occurrences="1">
-      <code>StoreId</code>
-    </DeprecatedClass>
-  </file>
   <file src="src/Value/Arithmetic/Amount.php">
-    <MissingParamType occurrences="1">
+    <MissingParamType>
       <code>$value</code>
     </MissingParamType>
   </file>
   <file src="src/Value/Contact/PhoneNumber.php">
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$this-&gt;value-&gt;getNationalNumber()</code>
     </PossiblyNullArgument>
   </file>
   <file src="src/Value/Monetary/Amount.php">
-    <MissingParamType occurrences="1">
+    <MissingParamType>
       <code>$value</code>
     </MissingParamType>
   </file>
   <file src="src/Value/Money/Money.php">
-    <ArgumentTypeCoercion occurrences="3">
+    <ArgumentTypeCoercion>
       <code>(string) $this-&gt;amount</code>
       <code>\sprintf('1%s', \str_repeat('0', $currency-&gt;getMinorUnit()))</code>
       <code>\sprintf('1%s', \str_repeat('0', $this-&gt;currency-&gt;getMinorUnit()))</code>
     </ArgumentTypeCoercion>
   </file>
   <file src="src/Value/Money/Price.php">
-    <ArgumentTypeCoercion occurrences="2">
+    <ArgumentTypeCoercion>
       <code>(string) $amount</code>
       <code>(string) $amount</code>
     </ArgumentTypeCoercion>
   </file>
   <file src="src/Value/RegionCode.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>null === $code</code>
     </DocblockTypeContradiction>
   </file>
   <file src="src/Value/Web/DomainName.php">
-    <ImpureMethodCall occurrences="16">
+    <ImpureMethodCall>
       <code>fromString</code>
       <code>registrableDomain</code>
       <code>registrableDomain</code>
@@ -128,19 +72,19 @@
       <code>value</code>
       <code>value</code>
     </ImpureMethodCall>
-    <ImpureStaticProperty occurrences="3">
+    <ImpureStaticProperty>
       <code>self::$rules</code>
       <code>self::$rules</code>
       <code>self::$rules</code>
     </ImpureStaticProperty>
   </file>
   <file src="src/Value/Web/IPAddress.php">
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(string) $this-&gt;value</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Value/Web/Url.php">
-    <ImpureMethodCall occurrences="28">
+    <ImpureMethodCall>
       <code>__toString</code>
       <code>getAuthority</code>
       <code>getFragment</code>
@@ -170,27 +114,9 @@
       <code>withScheme</code>
       <code>withUserInfo</code>
     </ImpureMethodCall>
-    <LessSpecificReturnStatement occurrences="7">
-      <code>new self($this-&gt;leagueUri-&gt;withFragment($fragment))</code>
-      <code>new self($this-&gt;leagueUri-&gt;withHost($host))</code>
-      <code>new self($this-&gt;leagueUri-&gt;withPath($path))</code>
-      <code>new self($this-&gt;leagueUri-&gt;withPort($port))</code>
-      <code>new self($this-&gt;leagueUri-&gt;withQuery($query))</code>
-      <code>new self($this-&gt;leagueUri-&gt;withScheme($scheme))</code>
-      <code>new self($this-&gt;leagueUri-&gt;withUserInfo($user, $password))</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="7">
-      <code>self</code>
-      <code>self</code>
-      <code>self</code>
-      <code>self</code>
-      <code>self</code>
-      <code>self</code>
-      <code>self</code>
-    </MoreSpecificReturnType>
   </file>
   <file src="src/Value/Web/UrlPath.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>\is_string($value)</code>
     </DocblockTypeContradiction>
   </file>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -2,6 +2,8 @@
 
 <psalm errorBaseline="psalm-baseline.xml"
        errorLevel="2"
+       findUnusedBaselineEntry="true"
+       findUnusedCode="false"
        resolveFromConfigFile="true"
        usePhpDocMethodsWithoutMagicCall="true"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/Assertion/EnumValueGuardTrait.php
+++ b/src/Assertion/EnumValueGuardTrait.php
@@ -24,6 +24,7 @@ trait EnumValueGuardTrait
         $validValues = $this->getValidValues();
 
         if (!\in_array($value, $validValues, true)) {
+            /** @psalm-suppress ArgumentTypeCoercion */
             throw new \InvalidArgumentException(
                 \sprintf(
                     'Invalid %s value given: "%s" (valid values: %s)',

--- a/src/Collection/ImmutableCollectionInterface.php
+++ b/src/Collection/ImmutableCollectionInterface.php
@@ -6,8 +6,8 @@ namespace MyOnlineStore\Common\Domain\Collection;
 /**
  * @template TKey of array-key
  * @template T
- * @implements \IteratorAggregate<TKey, T>
- * @implements \ArrayAccess<TKey, T>
+ * @extends \IteratorAggregate<TKey, T>
+ * @extends \ArrayAccess<TKey, T>
  */
 interface ImmutableCollectionInterface extends \ArrayAccess, \Countable, \IteratorAggregate
 {

--- a/src/Collection/RegionCodeCollection.php
+++ b/src/Collection/RegionCodeCollection.php
@@ -5,12 +5,10 @@ namespace MyOnlineStore\Common\Domain\Collection;
 
 use MyOnlineStore\Common\Domain\Value\RegionCode;
 
-/**
- * @extends ImmutableCollection<array-key, RegionCode>
- * @use StringCollectionTrait<array-key, RegionCode>
- */
+/** @extends ImmutableCollection<array-key, RegionCode> */
 final class RegionCodeCollection extends ImmutableCollection implements RegionCodeCollectionInterface
 {
+    /** @use StringCollectionTrait<array-key, RegionCode> */
     use StringCollectionTrait;
 
     /** @inheritdoc */

--- a/src/Collection/RegionCodeCollectionInterface.php
+++ b/src/Collection/RegionCodeCollectionInterface.php
@@ -5,12 +5,11 @@ namespace MyOnlineStore\Common\Domain\Collection;
 
 use MyOnlineStore\Common\Domain\Value\RegionCode;
 
-/** @method RegionCode[] getIterator() */
+/** @extends ImmutableCollectionInterface<array-key, RegionCode> */
 interface RegionCodeCollectionInterface extends ImmutableCollectionInterface, StringCollectionInterface
 {
     /** @return RegionCodeCollectionInterface */
     public function reindex();
 
-    /** @return RegionCodeCollectionInterface */
     public function unique(): RegionCodeCollectionInterface;
 }

--- a/src/Collection/StoreIds.php
+++ b/src/Collection/StoreIds.php
@@ -5,12 +5,10 @@ namespace MyOnlineStore\Common\Domain\Collection;
 
 use MyOnlineStore\Common\Domain\Value\StoreId;
 
-/**
- * @extends ImmutableCollection<array-key, StoreId>
- * @use StringCollectionTrait<array-key, StoreId>
- */
+/** @extends ImmutableCollection<array-key, StoreId> */
 final class StoreIds extends ImmutableCollection implements StoreIdsInterface
 {
+    /** @use StringCollectionTrait<array-key, StoreId> */
     use StringCollectionTrait;
 
     /** @param StoreId[]|int[] $entries */

--- a/src/Collection/StoreIdsInterface.php
+++ b/src/Collection/StoreIdsInterface.php
@@ -5,7 +5,7 @@ namespace MyOnlineStore\Common\Domain\Collection;
 
 use MyOnlineStore\Common\Domain\Value\StoreId;
 
-/** @method StoreId[] getIterator() */
+/** @extends ImmutableCollectionInterface<array-key, StoreId> */
 interface StoreIdsInterface extends ImmutableCollectionInterface
 {
     /** @throws \InvalidArgumentException */

--- a/src/Exception/Color/InvalidHexColor.php
+++ b/src/Exception/Color/InvalidHexColor.php
@@ -9,7 +9,7 @@ use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 final class InvalidHexColor extends InvalidArgument
 {
     /** @psalm-pure */
-    public static function withHexColor(string $color, \Throwable|null $previous = null): self
+    public static function withHexColor(string $color, \Throwable | null $previous = null): self
     {
         return new self(
             \sprintf(

--- a/src/Value/Arithmetic/Number.php
+++ b/src/Value/Arithmetic/Number.php
@@ -17,7 +17,7 @@ class Number
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($value, int|null $scale = null)
+    public function __construct($value, int | null $scale = null)
     {
         $this->assignValue($value, $scale);
     }
@@ -28,7 +28,7 @@ class Number
     }
 
     /** @return static */
-    public function add(Number $operand, int|null $scale = null)
+    public function add(Number $operand, int | null $scale = null)
     {
         $this->assertOperand($operand);
 
@@ -43,7 +43,7 @@ class Number
      *
      * @throws \InvalidArgumentException
      */
-    public function changeValue($value, int|null $scale = null)
+    public function changeValue($value, int | null $scale = null)
     {
         $newMetric = clone $this;
         $newMetric->assignValue($value, $scale);
@@ -52,7 +52,7 @@ class Number
     }
 
     /** @return static */
-    public function divideBy(Number $operand, int|null $scale = null)
+    public function divideBy(Number $operand, int | null $scale = null)
     {
         $this->assertOperand($operand);
 
@@ -60,7 +60,7 @@ class Number
         return $this->changeValue($this->value->div($operand->value, $scale), $scale);
     }
 
-    public function equals(Number $operand, int|null $scale = null): bool
+    public function equals(Number $operand, int | null $scale = null): bool
     {
         $this->assertOperand($operand);
 
@@ -68,13 +68,13 @@ class Number
         return $this->value->equals($operand->value, $scale);
     }
 
-    public function isGreaterThan(Number $operand, int|null $scale = null): bool
+    public function isGreaterThan(Number $operand, int | null $scale = null): bool
     {
         /** @psalm-suppress ImpureMethodCall */
         return 1 === $this->value->comp($operand->value, $scale);
     }
 
-    public function isLessThan(Number $operand, int|null $scale = null): bool
+    public function isLessThan(Number $operand, int | null $scale = null): bool
     {
         /** @psalm-suppress ImpureMethodCall */
         return -1 === $this->value->comp($operand->value, $scale);
@@ -87,7 +87,7 @@ class Number
     }
 
     /** @return static */
-    public function multiplyBy(Number $operand, int|null $scale = null)
+    public function multiplyBy(Number $operand, int | null $scale = null)
     {
         $this->assertOperand($operand);
 
@@ -96,14 +96,14 @@ class Number
     }
 
     /** @return static */
-    public function powerTo(Number $operand, int|null $scale = null)
+    public function powerTo(Number $operand, int | null $scale = null)
     {
         /** @psalm-suppress ImpureMethodCall */
         return $this->changeValue($this->value->pow($operand->value, $scale));
     }
 
     /** @return static */
-    public function subtract(Number $operand, int|null $scale = null)
+    public function subtract(Number $operand, int | null $scale = null)
     {
         $this->assertOperand($operand);
 
@@ -128,7 +128,7 @@ class Number
      *
      * @throws \InvalidArgumentException
      */
-    private function assignValue($value, int|null $scale = null): void
+    private function assignValue($value, int | null $scale = null): void
     {
         if ($value instanceof self) {
             $value = $value->value;

--- a/src/Value/Arithmetic/Percentage.php
+++ b/src/Value/Arithmetic/Percentage.php
@@ -13,7 +13,7 @@ use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
  */
 final class Percentage extends Number
 {
-    private function __construct(string $value, int|null $scale = null)
+    private function __construct(string $value, int | null $scale = null)
     {
         parent::__construct($value, $scale);
 
@@ -24,7 +24,7 @@ final class Percentage extends Number
     }
 
     /** @psalm-pure */
-    public static function fromString(string $value, int|null $scale = null): self
+    public static function fromString(string $value, int | null $scale = null): self
     {
         return new self($value, $scale);
     }

--- a/src/Value/Contact/PhoneNumber.php
+++ b/src/Value/Contact/PhoneNumber.php
@@ -24,7 +24,7 @@ final class PhoneNumber
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($value, RegionCode|null $regionCode = null)
+    public function __construct($value, RegionCode | null $regionCode = null)
     {
         $this->phoneNumberUtil = PhoneNumberUtil::getInstance();
 
@@ -59,7 +59,7 @@ final class PhoneNumber
         return 0 === \strcasecmp((string) $this, (string) $comparison);
     }
 
-    public function getCountryCode(): int|null
+    public function getCountryCode(): int | null
     {
         return $this->value->getCountryCode();
     }

--- a/src/Value/Location/Address/Street.php
+++ b/src/Value/Location/Address/Street.php
@@ -39,7 +39,7 @@ final class Street
      */
     private $suffix;
 
-    public function __construct(StreetName $name, StreetNumber $number, StreetSuffix|null $suffix = null)
+    public function __construct(StreetName $name, StreetNumber $number, StreetSuffix | null $suffix = null)
     {
         $this->name = $name;
         $this->number = $number;
@@ -83,7 +83,7 @@ final class Street
         return $this->number;
     }
 
-    public function getSuffix(): StreetSuffix|null
+    public function getSuffix(): StreetSuffix | null
     {
         return $this->suffix ? StreetSuffix::fromString($this->suffix) : null;
     }

--- a/src/Value/Web/DomainName.php
+++ b/src/Value/Web/DomainName.php
@@ -12,7 +12,7 @@ use Pdp\SyntaxError;
 final class DomainName
 {
     private ResolvedDomainName $resolvedDomainName;
-    private static Rules|null $rules = null;
+    private static Rules | null $rules = null;
 
     /** @throws \InvalidArgumentException */
     public function __construct(string $domainName)
@@ -42,7 +42,7 @@ final class DomainName
     }
 
     /** @deprecated Should be extracted to external service */
-    public function getHostName(): string|null
+    public function getHostName(): string | null
     {
         return \explode('.', $this->resolvedDomainName->registrableDomain()->toString(), 2)[0] ?? null;
     }
@@ -60,13 +60,13 @@ final class DomainName
     }
 
     /** @deprecated Should be extracted to external service */
-    public function getSubdomain(): string|null
+    public function getSubdomain(): string | null
     {
         return $this->resolvedDomainName->subDomain()->value();
     }
 
     /** @deprecated Should be extracted to external service */
-    public function getTld(): string|null
+    public function getTld(): string | null
     {
         return $this->resolvedDomainName->suffix()->value();
     }
@@ -80,7 +80,7 @@ final class DomainName
     {
         if (null === self::$rules) {
             self::$rules = Rules::fromString(
-                <<<RULES
+                <<<'RULES'
 
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/Value/Web/Url.php
+++ b/src/Value/Web/Url.php
@@ -62,7 +62,7 @@ final class Url implements Psr7UriInterface
      *
      * @param Psr7UriInterface|UriInterface $uri the input URI to create
      */
-    public static function createFromUri(Psr7UriInterface|UriInterface $uri): self
+    public static function createFromUri(Psr7UriInterface | UriInterface $uri): self
     {
         return new self(Http::createFromUri($uri));
     }

--- a/tests/Assertion/ArrayContainsClassAssertionTraitTest.php
+++ b/tests/Assertion/ArrayContainsClassAssertionTraitTest.php
@@ -13,9 +13,8 @@ final class ArrayContainsClassAssertionTraitTest extends TestCase
     {
         $trait = $this->getMockForTrait(ArrayContainsClassAssertionTrait::class);
 
-        $reflection = new \ReflectionClass(\get_class($trait));
+        $reflection = new \ReflectionClass($trait::class);
         $assertion = $reflection->getMethod('assertArrayContainsOnlyClass');
-        $assertion->setAccessible(true);
 
         self::assertTrue($assertion->invoke($trait, [new \stdClass()], \stdClass::class));
         self::assertFalse($assertion->invoke($trait, [new \stdClass(), Locale::fromString('nl_NL')], \stdClass::class));

--- a/tests/Assertion/EnumValueGuardTraitTest.php
+++ b/tests/Assertion/EnumValueGuardTraitTest.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 namespace MyOnlineStore\Common\Domain\Tests\Assertion;
 
 use MyOnlineStore\Common\Domain\Assertion\EnumValueGuardTrait;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class EnumValueGuardTraitTest extends TestCase
 {
-    /** @var EnumValueGuardTrait */
-    private $trait;
+    /** @var MockObject&EnumValueGuardTrait */
+    private MockObject $trait;
 
     protected function setUp(): void
     {

--- a/tests/Assertion/NumericAssertionTraitTest.php
+++ b/tests/Assertion/NumericAssertionTraitTest.php
@@ -12,9 +12,8 @@ final class NumericAssertionTraitTest extends TestCase
     {
         $trait = $this->getMockForTrait(NumericAssertionTrait::class);
 
-        $reflection = new \ReflectionClass(\get_class($trait));
+        $reflection = new \ReflectionClass($trait::class);
         $assertion = $reflection->getMethod('assertIsNumeric');
-        $assertion->setAccessible(true);
 
         self::assertFalse($assertion->invoke($trait, 'foo'));
         self::assertTrue($assertion->invoke($trait, 10));

--- a/tests/Value/Arithmetic/AmountTest.php
+++ b/tests/Value/Arithmetic/AmountTest.php
@@ -4,41 +4,34 @@ declare(strict_types=1);
 namespace MyOnlineStore\Common\Domain\Tests\Value\Arithmetic;
 
 use MyOnlineStore\Common\Domain\Value\Arithmetic\Amount;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class AmountTest extends TestCase
 {
-    public function invalidInputProvider(): \Generator
+    public static function invalidInputProvider(): \Generator
     {
         yield ['1.23'];
         yield [1.23];
         yield ['a'];
     }
 
-    /**
-     * @dataProvider invalidInputProvider
-     *
-     * @param mixed $input
-     */
-    public function testInvalidInput($input): void
+    #[DataProvider('invalidInputProvider')]
+    public function testInvalidInput(mixed $input): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
         new Amount($input);
     }
 
-    public function validInputProvider(): \Generator
+    public static function validInputProvider(): \Generator
     {
         yield [123];
         yield ['123'];
     }
 
-    /**
-     * @dataProvider validInputProvider
-     *
-     * @param mixed $input
-     */
-    public function testValidInput($input): void
+    #[DataProvider('validInputProvider')]
+    public function testValidInput(mixed $input): void
     {
         self::assertInstanceOf(Amount::class, new Amount($input));
     }

--- a/tests/Value/Arithmetic/NumberTest.php
+++ b/tests/Value/Arithmetic/NumberTest.php
@@ -32,7 +32,7 @@ final class NumberTest extends TestCase
 
         $numberMock = $this->getMockBuilder(Number::class)
             ->setConstructorArgs([123])
-            ->setMethods(['assertOperand'])
+            ->onlyMethods(['assertOperand'])
             ->getMockForAbstractClass();
 
         $numberMock->expects(self::exactly(5))->method('assertOperand')->with($operand);
@@ -50,8 +50,8 @@ final class NumberTest extends TestCase
         $subclassedNumber = $this->createSubclassedNumber(123);
         $newSubclassedNumber = $subclassedNumber->add(new Number(543));
 
-        self::assertNotEquals(\get_class($subclassedNumber), Number::class);
-        self::assertInstanceOf(\get_class($subclassedNumber), $newSubclassedNumber);
+        self::assertNotEquals($subclassedNumber::class, Number::class);
+        self::assertInstanceOf($subclassedNumber::class, $newSubclassedNumber);
         self::assertEquals($this->createSubclassedNumber(666), $newSubclassedNumber);
 
         self::assertEquals(new Number(666), (new Number(543))->add($subclassedNumber));
@@ -150,12 +150,7 @@ final class NumberTest extends TestCase
         self::assertEquals(new Number(1.23, 2), (new Number(123))->toScale(2));
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @return MockObject|Number
-     */
-    private function createSubclassedNumber($value)
+    private function createSubclassedNumber(mixed $value): MockObject | Number
     {
         return $this->getMockBuilder(Number::class)->setConstructorArgs([$value])->getMockForAbstractClass();
     }

--- a/tests/Value/Color/HexColorTest.php
+++ b/tests/Value/Color/HexColorTest.php
@@ -5,12 +5,13 @@ namespace MyOnlineStore\Common\Domain\Tests\Value\Color;
 
 use MyOnlineStore\Common\Domain\Exception\Color\InvalidHexColor;
 use MyOnlineStore\Common\Domain\Value\Color\HexColor;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class HexColorTest extends TestCase
 {
     /** @return iterable<array{string}> */
-    public function invalidStringProvider(): iterable
+    public static function invalidStringProvider(): iterable
     {
         yield ['#'];
         yield ['#1'];
@@ -38,7 +39,7 @@ final class HexColorTest extends TestCase
         self::assertEquals('#112233', HexColor::fromString('#123')->toString());
     }
 
-    /** @dataProvider invalidStringProvider */
+    #[DataProvider('invalidStringProvider')]
     public function testInvalidStringValues(string $value): void
     {
         $this->expectException(InvalidHexColor::class);

--- a/tests/Value/Contact/PhoneNumberTest.php
+++ b/tests/Value/Contact/PhoneNumberTest.php
@@ -5,12 +5,13 @@ namespace MyOnlineStore\Common\Domain\Tests\Value\Contact;
 
 use MyOnlineStore\Common\Domain\Value\Contact\PhoneNumber;
 use MyOnlineStore\Common\Domain\Value\RegionCode;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class PhoneNumberTest extends TestCase
 {
     /** @return string[][] */
-    public function getInvalidStringValues(): array
+    public static function getInvalidStringValues(): array
     {
         return [
             ['+313'],
@@ -21,7 +22,7 @@ final class PhoneNumberTest extends TestCase
     }
 
     /** @return string[][] */
-    public function getValidStringValues(): array
+    public static function getValidStringValues(): array
     {
         return [
             ['0031882315726'],
@@ -34,7 +35,7 @@ final class PhoneNumberTest extends TestCase
     }
 
     /** @return mixed[][] */
-    public function shortInternationalFormatProvider(): array
+    public static function shortInternationalFormatProvider(): array
     {
         return [
             ['+321882315726', new PhoneNumber('1882315726', new RegionCode('BE'))],
@@ -48,7 +49,7 @@ final class PhoneNumberTest extends TestCase
     }
 
     /** @return mixed[][] */
-    public function equalPhoneNumberProvider(): array
+    public static function equalPhoneNumberProvider(): array
     {
         return [
             [false, new PhoneNumber('0031612483496'), new PhoneNumber('0031612483497')],
@@ -59,7 +60,7 @@ final class PhoneNumberTest extends TestCase
         ];
     }
 
-    /** @dataProvider equalPhoneNumberProvider */
+    #[DataProvider('equalPhoneNumberProvider')]
     public function testEqualsWillReturnFormatterEquality(
         bool $expectedResult,
         PhoneNumber $phoneNumber,
@@ -95,13 +96,13 @@ final class PhoneNumberTest extends TestCase
         self::assertEquals('+44882315726', (string) $phoneNumber->withRegionCode(new RegionCode('GB')));
     }
 
-    /** @dataProvider shortInternationalFormatProvider */
+    #[DataProvider('shortInternationalFormatProvider')]
     public function testShortInternationalFormat(string $expectedFormat, PhoneNumber $phoneNumber): void
     {
         self::assertEquals($expectedFormat, $phoneNumber->getShortInternationalFormat());
     }
 
-    /** @dataProvider getInvalidStringValues */
+    #[DataProvider('getInvalidStringValues')]
     public function testInvalidStringValues(string $value): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -135,7 +136,7 @@ final class PhoneNumberTest extends TestCase
         self::assertEquals($phoneNumber->getShortInternationalFormat(), (string) $phoneNumber);
     }
 
-    /** @dataProvider getValidStringValues */
+    #[DataProvider('getValidStringValues')]
     public function testValidStringValues(string $value): void
     {
         self::assertInstanceOf(PhoneNumber::class, new PhoneNumber($value));

--- a/tests/Value/LanguageCodeTest.php
+++ b/tests/Value/LanguageCodeTest.php
@@ -5,11 +5,12 @@ namespace MyOnlineStore\Common\Domain\Tests\Value;
 
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 use MyOnlineStore\Common\Domain\Value\LanguageCode;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class LanguageCodeTest extends TestCase
 {
-    /** @dataProvider invalidArgumentProvider */
+    #[DataProvider('invalidArgumentProvider')]
     public function testInvalidTypes(string $argument): void
     {
         $this->expectException(InvalidArgument::class);
@@ -30,7 +31,7 @@ final class LanguageCodeTest extends TestCase
     }
 
     /** @return string[][] */
-    public function invalidArgumentProvider(): array
+    public static function invalidArgumentProvider(): array
     {
         return [
             ['n'],

--- a/tests/Value/LocaleTest.php
+++ b/tests/Value/LocaleTest.php
@@ -7,6 +7,7 @@ use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 use MyOnlineStore\Common\Domain\Value\LanguageCode;
 use MyOnlineStore\Common\Domain\Value\Locale;
 use MyOnlineStore\Common\Domain\Value\RegionCode;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class LocaleTest extends TestCase
@@ -17,12 +18,8 @@ final class LocaleTest extends TestCase
         self::assertFalse(Locale::fromString('nl_BE')->equals(Locale::fromString('nl_NL')));
     }
 
-    /**
-     * @dataProvider invalidArgumentProvider
-     *
-     * @param mixed $argument
-     */
-    public function testFromInvalidString($argument): void
+    #[DataProvider('invalidArgumentProvider')]
+    public function testFromInvalidString(mixed $argument): void
     {
         $this->expectException(InvalidArgument::class);
         Locale::fromString($argument);
@@ -63,7 +60,7 @@ final class LocaleTest extends TestCase
     }
 
     /** @return string[][] */
-    public function invalidArgumentProvider(): array
+    public static function invalidArgumentProvider(): array
     {
         return [
             [123],

--- a/tests/Value/Location/Address/CityTest.php
+++ b/tests/Value/Location/Address/CityTest.php
@@ -5,6 +5,7 @@ namespace MyOnlineStore\Common\Domain\Tests\Value\Location\Address;
 
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 use MyOnlineStore\Common\Domain\Value\Location\Address\City;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class CityTest extends TestCase
@@ -14,7 +15,7 @@ final class CityTest extends TestCase
         self::assertSame('foo', (string) City::fromString('foo'));
     }
 
-    public function emptyDataProvider(): \Generator
+    public static function emptyDataProvider(): \Generator
     {
         yield [''];
         yield [' '];
@@ -23,7 +24,7 @@ final class CityTest extends TestCase
         yield ["\t "];
     }
 
-    /** @dataProvider emptyDataProvider */
+    #[DataProvider('emptyDataProvider')]
     public function testEmpty(string $empty): void
     {
         $this->expectException(InvalidArgument::class);

--- a/tests/Value/Location/Address/StreetNameTest.php
+++ b/tests/Value/Location/Address/StreetNameTest.php
@@ -5,6 +5,7 @@ namespace MyOnlineStore\Common\Domain\Tests\Value\Location\Address;
 
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 use MyOnlineStore\Common\Domain\Value\Location\Address\StreetName;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class StreetNameTest extends TestCase
@@ -15,7 +16,7 @@ final class StreetNameTest extends TestCase
         self::assertSame('foo', (string) StreetName::fromString(' foo '));
     }
 
-    public function emptyDataProvider(): \Generator
+    public static function emptyDataProvider(): \Generator
     {
         yield [''];
         yield [' '];
@@ -24,7 +25,7 @@ final class StreetNameTest extends TestCase
         yield ["\t "];
     }
 
-    /** @dataProvider emptyDataProvider */
+    #[DataProvider('emptyDataProvider')]
     public function testEmpty(string $empty): void
     {
         $this->expectException(InvalidArgument::class);

--- a/tests/Value/Location/Address/StreetNumberTest.php
+++ b/tests/Value/Location/Address/StreetNumberTest.php
@@ -5,6 +5,7 @@ namespace MyOnlineStore\Common\Domain\Tests\Value\Location\Address;
 
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 use MyOnlineStore\Common\Domain\Value\Location\Address\StreetNumber;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class StreetNumberTest extends TestCase
@@ -15,7 +16,7 @@ final class StreetNumberTest extends TestCase
         self::assertSame('foo', (string) StreetNumber::fromString(' foo '));
     }
 
-    public function emptyDataProvider(): \Generator
+    public static function emptyDataProvider(): \Generator
     {
         yield [''];
         yield [' '];
@@ -24,7 +25,7 @@ final class StreetNumberTest extends TestCase
         yield ["\t "];
     }
 
-    /** @dataProvider emptyDataProvider */
+    #[DataProvider('emptyDataProvider')]
     public function testEmpty(string $empty): void
     {
         $this->expectException(InvalidArgument::class);

--- a/tests/Value/Location/Address/StreetSuffixTest.php
+++ b/tests/Value/Location/Address/StreetSuffixTest.php
@@ -5,6 +5,7 @@ namespace MyOnlineStore\Common\Domain\Tests\Value\Location\Address;
 
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 use MyOnlineStore\Common\Domain\Value\Location\Address\StreetSuffix;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class StreetSuffixTest extends TestCase
@@ -15,7 +16,7 @@ final class StreetSuffixTest extends TestCase
         self::assertSame('foo', (string) StreetSuffix::fromString(' foo '));
     }
 
-    public function emptyDataProvider(): \Generator
+    public static function emptyDataProvider(): \Generator
     {
         yield [''];
         yield [' '];
@@ -24,7 +25,7 @@ final class StreetSuffixTest extends TestCase
         yield ["\t "];
     }
 
-    /** @dataProvider emptyDataProvider */
+    #[DataProvider('emptyDataProvider')]
     public function testEmpty(string $empty): void
     {
         $this->expectException(InvalidArgument::class);

--- a/tests/Value/Location/Address/StreetTest.php
+++ b/tests/Value/Location/Address/StreetTest.php
@@ -8,11 +8,12 @@ use MyOnlineStore\Common\Domain\Value\Location\Address\Street;
 use MyOnlineStore\Common\Domain\Value\Location\Address\StreetName;
 use MyOnlineStore\Common\Domain\Value\Location\Address\StreetNumber;
 use MyOnlineStore\Common\Domain\Value\Location\Address\StreetSuffix;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class StreetTest extends TestCase
 {
-    public function dataFromSingleLine(): \Generator
+    public static function dataFromSingleLine(): \Generator
     {
         yield ['foo 12a', 'foo', '12', 'a'];
         yield ['foo 12 a', 'foo', '12', 'a'];
@@ -90,8 +91,8 @@ final class StreetTest extends TestCase
         );
     }
 
-    /** @dataProvider dataFromSingleLine */
-    public function testFromSingleLine(string $line, string $street, string $number, string|null $suffix): void
+    #[DataProvider('dataFromSingleLine')]
+    public function testFromSingleLine(string $line, string $street, string $number, string | null $suffix): void
     {
         self::assertTrue(
             Street::fromSingleLine($line)->equals(

--- a/tests/Value/Monetary/AmountTest.php
+++ b/tests/Value/Monetary/AmountTest.php
@@ -4,41 +4,34 @@ declare(strict_types=1);
 namespace MyOnlineStore\Common\Domain\Tests\Value\Monetary;
 
 use MyOnlineStore\Common\Domain\Value\Monetary\Amount;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class AmountTest extends TestCase
 {
-    public function invalidInputProvider(): \Generator
+    public static function invalidInputProvider(): \Generator
     {
         yield ['1.23'];
         yield [1.23];
         yield ['a'];
     }
 
-    /**
-     * @dataProvider invalidInputProvider
-     *
-     * @param mixed $input
-     */
-    public function testInvalidInput($input): void
+    #[DataProvider('invalidInputProvider')]
+    public function testInvalidInput(mixed $input): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
         new Amount($input);
     }
 
-    public function validInputProvider(): \Generator
+    public static function validInputProvider(): \Generator
     {
         yield [123];
         yield ['123'];
     }
 
-    /**
-     * @dataProvider validInputProvider
-     *
-     * @param mixed $input
-     */
-    public function testValidInput($input): void
+    #[DataProvider('validInputProvider')]
+    public function testValidInput(mixed $input): void
     {
         self::assertInstanceOf(Amount::class, new Amount($input));
     }

--- a/tests/Value/Money/CurrencyIsoTest.php
+++ b/tests/Value/Money/CurrencyIsoTest.php
@@ -5,6 +5,7 @@ namespace MyOnlineStore\Common\Domain\Tests\Value\Money;
 
 use MyOnlineStore\Common\Domain\Exception\Currency\InvalidCurrencyIso;
 use MyOnlineStore\Common\Domain\Value\Money\CurrencyIso;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class CurrencyIsoTest extends TestCase
@@ -33,7 +34,7 @@ final class CurrencyIsoTest extends TestCase
         ));
     }
 
-    /** @dataProvider invalidArgumentProvider */
+    #[DataProvider('invalidArgumentProvider')]
     public function testInvalidTypes(string $argument): void
     {
         $this->expectException(InvalidCurrencyIso::class);
@@ -56,7 +57,7 @@ final class CurrencyIsoTest extends TestCase
     }
 
     /** @return string[][] */
-    public function invalidArgumentProvider(): array
+    public static function invalidArgumentProvider(): array
     {
         return [
             ['EU'],

--- a/tests/Value/Money/MoneyTest.php
+++ b/tests/Value/Money/MoneyTest.php
@@ -6,19 +6,20 @@ namespace MyOnlineStore\Common\Domain\Tests\Value\Money;
 use MyOnlineStore\Common\Domain\Value\Arithmetic\Amount;
 use MyOnlineStore\Common\Domain\Value\Money\CurrencyIso;
 use MyOnlineStore\Common\Domain\Value\Money\Money;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class MoneyTest extends TestCase
 {
     /** @return mixed[] */
-    public function fractionedArgumentProvider(): array
+    public static function fractionedArgumentProvider(): array
     {
         return [
-            ['131231', CurrencyIso::fromString('EUR'), '131231.00', 13123100],
+            ['131231', CurrencyIso::fromString('EUR'), '131231.00', 13_123_100],
             ['464.4534', CurrencyIso::fromString('EUR'), '464.45', 46445],
-            ['-23123.23', CurrencyIso::fromString('EUR'), '-23123.23', -2312323],
+            ['-23123.23', CurrencyIso::fromString('EUR'), '-23123.23', -2_312_323],
             ['0.2323232', CurrencyIso::fromString('USD'), '0.23', 23],
-            ['2323232', CurrencyIso::fromString('XXX'), '2323232', 2323232],
+            ['2323232', CurrencyIso::fromString('XXX'), '2323232', 2_323_232],
             ['232.3232', CurrencyIso::fromString('IQD'), '232.323', 232323],
             ['11.999998', CurrencyIso::fromString('EUR'), '12.00', 1200],
             [11.999998, CurrencyIso::fromString('EUR'), '12.00', 1200],
@@ -58,12 +59,8 @@ final class MoneyTest extends TestCase
         Money::fromFractionated('34535,34', CurrencyIso::fromString('USD'));
     }
 
-    /**
-     * @dataProvider fractionedArgumentProvider
-     *
-     * @param mixed $amount
-     */
-    public function testFromFractioned($amount, CurrencyIso $currency, string $expectedString, int $expectedWhole): void
+    #[DataProvider('fractionedArgumentProvider')]
+    public function testFromFractioned(mixed $amount, CurrencyIso $currency, string $expectedString, int $expectedWhole): void
     {
         $money = Money::fromFractionated($amount, $currency);
         self::assertEquals($expectedString, (string) $money);
@@ -71,12 +68,8 @@ final class MoneyTest extends TestCase
         self::assertSame($currency, $money->getCurrency());
     }
 
-    /**
-     * @dataProvider wholeArgumentProvider
-     *
-     * @param mixed $amount
-     */
-    public function testFromWhole($amount, CurrencyIso $currency, string $expectedString, int $expectedWhole): void
+    #[DataProvider('wholeArgumentProvider')]
+    public function testFromWhole(mixed $amount, CurrencyIso $currency, string $expectedString, int $expectedWhole): void
     {
         $money = new Money($amount, $currency);
         self::assertEquals($expectedString, (string) $money);
@@ -85,12 +78,12 @@ final class MoneyTest extends TestCase
     }
 
     /** @return mixed[] */
-    public function wholeArgumentProvider(): array
+    public static function wholeArgumentProvider(): array
     {
         return [
             [new Amount('131231'), CurrencyIso::fromString('EUR'), '1312.31', 131231],
             [new Amount('-23123'), CurrencyIso::fromString('EUR'), '-231.23', -23123],
-            [new Amount('02323232'), CurrencyIso::fromString('USD'), '23232.32', 2323232],
+            [new Amount('02323232'), CurrencyIso::fromString('USD'), '23232.32', 2_323_232],
             [new Amount('1337'), CurrencyIso::fromString('XXX'), '1337', 1337],
             [new Amount('-1337'), CurrencyIso::fromString('IQD'), '-1.337', -1337],
         ];

--- a/tests/Value/Person/Name/FirstNameTest.php
+++ b/tests/Value/Person/Name/FirstNameTest.php
@@ -5,6 +5,7 @@ namespace MyOnlineStore\Common\Domain\Tests\Value\Person\Name;
 
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 use MyOnlineStore\Common\Domain\Value\Person\Name\FirstName;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class FirstNameTest extends TestCase
@@ -14,7 +15,7 @@ final class FirstNameTest extends TestCase
         self::assertSame('foo', (string) FirstName::fromString('foo'));
     }
 
-    public function emptyDataProvider(): \Generator
+    public static function emptyDataProvider(): \Generator
     {
         yield [''];
         yield [' '];
@@ -23,7 +24,7 @@ final class FirstNameTest extends TestCase
         yield ["\t "];
     }
 
-    /** @dataProvider emptyDataProvider */
+    #[DataProvider('emptyDataProvider')]
     public function testEmpty(string $empty): void
     {
         $this->expectException(InvalidArgument::class);

--- a/tests/Value/Person/Name/LastNameTest.php
+++ b/tests/Value/Person/Name/LastNameTest.php
@@ -5,6 +5,7 @@ namespace MyOnlineStore\Common\Domain\Tests\Value\Person\Name;
 
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 use MyOnlineStore\Common\Domain\Value\Person\Name\LastName;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class LastNameTest extends TestCase
@@ -14,7 +15,7 @@ final class LastNameTest extends TestCase
         self::assertSame('foo', (string) LastName::fromString('foo'));
     }
 
-    public function emptyDataProvider(): \Generator
+    public static function emptyDataProvider(): \Generator
     {
         yield [''];
         yield [' '];
@@ -23,7 +24,7 @@ final class LastNameTest extends TestCase
         yield ["\t "];
     }
 
-    /** @dataProvider emptyDataProvider */
+    #[DataProvider('emptyDataProvider')]
     public function testEmpty(string $empty): void
     {
         $this->expectException(InvalidArgument::class);

--- a/tests/Value/RegionCodeTest.php
+++ b/tests/Value/RegionCodeTest.php
@@ -5,6 +5,7 @@ namespace MyOnlineStore\Common\Domain\Tests\Value;
 
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 use MyOnlineStore\Common\Domain\Value\RegionCode;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class RegionCodeTest extends TestCase
@@ -16,8 +17,8 @@ final class RegionCodeTest extends TestCase
         self::assertFalse($regionCode->equals(new RegionCode('DE')));
     }
 
-    /** @dataProvider invalidArgumentProvider */
-    public function testInvalidTypes(string|null $argument): void
+    #[DataProvider('invalidArgumentProvider')]
+    public function testInvalidTypes(string | null $argument): void
     {
         $this->expectException(InvalidArgument::class);
         new RegionCode($argument);
@@ -38,7 +39,7 @@ final class RegionCodeTest extends TestCase
     }
 
     /** @return string[][]|null[][] */
-    public function invalidArgumentProvider(): array
+    public static function invalidArgumentProvider(): array
     {
         return [
             ['N'],
@@ -49,7 +50,7 @@ final class RegionCodeTest extends TestCase
     }
 
     /** @return \Generator<array{RegionCode, bool}> */
-    public function isEuRegionProvider(): \Generator
+    public static function isEuRegionProvider(): \Generator
     {
         yield [new RegionCode('AT'), true];
         yield [new RegionCode('BE'), true];
@@ -83,7 +84,7 @@ final class RegionCodeTest extends TestCase
         yield [new RegionCode('GB'), false];
     }
 
-    /** @dataProvider isEuRegionProvider */
+    #[DataProvider('isEuRegionProvider')]
     public function testIsEuRegion(RegionCode $regionCode, bool $expected): void
     {
         self::assertEquals($expected, $regionCode->isEuRegion());

--- a/tests/Value/Web/DomainNameTest.php
+++ b/tests/Value/Web/DomainNameTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace MyOnlineStore\Common\Domain\Tests\Value\Web;
 
 use MyOnlineStore\Common\Domain\Value\Web\DomainName;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class DomainNameTest extends TestCase
@@ -13,19 +14,15 @@ final class DomainNameTest extends TestCase
         self::assertEquals('foo.bar', (string) new DomainName('foo.bar'));
     }
 
-    /**
-     * @dataProvider getInvalidStringValues
-     *
-     * @param mixed $value
-     */
-    public function testInvalidStringValues($value): void
+    #[DataProvider('getInvalidStringValues')]
+    public function testInvalidStringValues(mixed $value): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
         new DomainName($value);
     }
 
-    /** @dataProvider getValidStringValues */
+    #[DataProvider('getValidStringValues')]
     public function testValidStringValues(string $value): void
     {
         self::assertInstanceOf(DomainName::class, new DomainName($value));
@@ -72,7 +69,7 @@ final class DomainNameTest extends TestCase
     }
 
     /** @return string[][] */
-    public function getInvalidStringValues(): array
+    public static function getInvalidStringValues(): array
     {
         return [
             ['foo'],
@@ -80,7 +77,7 @@ final class DomainNameTest extends TestCase
     }
 
     /** @return string[][] */
-    public function getValidStringValues(): array
+    public static function getValidStringValues(): array
     {
         return [
             ['myonlinestore.com'],

--- a/tests/Value/Web/HostNameTest.php
+++ b/tests/Value/Web/HostNameTest.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 namespace MyOnlineStore\Common\Domain\Tests\Value\Web;
 
 use MyOnlineStore\Common\Domain\Value\Web\HostName;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class HostNameTest extends TestCase
 {
-    /** @dataProvider providerValidHostNames */
+    #[DataProvider('providerValidHostNames')]
     public function testValidHostNames(string $hostname): void
     {
         self::assertEquals($hostname, (string) new HostName($hostname));
     }
 
-    /** @dataProvider providerInvalidHostNames */
+    #[DataProvider('providerInvalidHostNames')]
     public function testInvalidHostNames(string $hostname): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -23,7 +24,7 @@ final class HostNameTest extends TestCase
     }
 
     /** @return string[][] */
-    public function providerInvalidHostNames(): array
+    public static function providerInvalidHostNames(): array
     {
         return [
             ['!jkfd.com'],
@@ -34,7 +35,7 @@ final class HostNameTest extends TestCase
     }
 
     /** @return string[][] */
-    public function providerValidHostNames(): array
+    public static function providerValidHostNames(): array
     {
         return [
             ['localhost'],

--- a/tests/Value/Web/IPAddressTest.php
+++ b/tests/Value/Web/IPAddressTest.php
@@ -50,7 +50,7 @@ final class IPAddressTest extends TestCase
     {
         $address = new IPAddress(self::IPV4_ADDRESS);
 
-        self::assertSame(3581795162, $address->asLong());
+        self::assertSame(3_581_795_162, $address->asLong());
     }
 
     public function testAsLongIpv6ShouldThrowError(): void

--- a/tests/Value/Web/UrlHostTest.php
+++ b/tests/Value/Web/UrlHostTest.php
@@ -6,17 +6,18 @@ namespace MyOnlineStore\Common\Domain\Tests\Value\Web;
 use MyOnlineStore\Common\Domain\Exception\Web\InvalidHostName;
 use MyOnlineStore\Common\Domain\Value\Web\DomainName;
 use MyOnlineStore\Common\Domain\Value\Web\UrlHost;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class UrlHostTest extends TestCase
 {
-    /** @dataProvider providerValidHostUrls */
+    #[DataProvider('providerValidHostUrls')]
     public function testValidUrlHosts(string $hostname): void
     {
         self::assertEquals($hostname, (string) new UrlHost($hostname));
     }
 
-    /** @dataProvider provider */
+    #[DataProvider('provider')]
     public function testInvalidUrlHost(string $hostname): void
     {
         $this->expectException(InvalidHostName::class);
@@ -29,7 +30,7 @@ class UrlHostTest extends TestCase
         self::assertEquals(new DomainName((string) $urlHost), $urlHost->getDomainName());
     }
 
-    /** @dataProvider providerValidHostUrls */
+    #[DataProvider('providerValidHostUrls')]
     public function testInValidDomainName(string $hostname): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -38,13 +39,13 @@ class UrlHostTest extends TestCase
         $urlHost->getDomainName();
     }
 
-    /** @dataProvider providerValidDomains */
+    #[DataProvider('providerValidDomains')]
     public function testValidDomainsFromDomainName(string $domainName): void
     {
         self::assertEquals($domainName, (string) UrlHost::fromDomainName(new DomainName($domainName)));
     }
 
-    /** @dataProvider providerValidHostUrls */
+    #[DataProvider('providerValidHostUrls')]
     public function testInvalidDomainsFromDomainName(string $domainName): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -53,7 +54,7 @@ class UrlHostTest extends TestCase
     }
 
     /** @return string[][] */
-    public function provider(): array
+    public static function provider(): array
     {
         return [
             ['!jkfd.com'],
@@ -64,7 +65,7 @@ class UrlHostTest extends TestCase
     }
 
     /** @return string[][] */
-    public function providerValidHostUrls(): array
+    public static function providerValidHostUrls(): array
     {
         return [
             ['localhost'],
@@ -74,7 +75,7 @@ class UrlHostTest extends TestCase
     }
 
     /** @return string[][] */
-    public function providerValidDomains(): array
+    public static function providerValidDomains(): array
     {
         return [
             ['localhost.nl'],

--- a/tests/Value/Web/UrlTest.php
+++ b/tests/Value/Web/UrlTest.php
@@ -5,12 +5,13 @@ namespace MyOnlineStore\Common\Domain\Tests\Value\Web;
 
 use League\Uri\Uri;
 use MyOnlineStore\Common\Domain\Value\Web\Url;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class UrlTest extends TestCase
 {
     /** @return string[][] */
-    public function validUrlDataProvider(): array
+    public static function validUrlDataProvider(): array
     {
         return [
             ['', '/'],
@@ -19,14 +20,14 @@ final class UrlTest extends TestCase
         ];
     }
 
-    /** @dataProvider validUrlDataProvider */
+    #[DataProvider('validUrlDataProvider')]
     public function testFromStringWillParseStringCorrectly(string $input): void
     {
         self::assertEquals((string) Uri::createFromString($input), (string) Url::fromString($input));
     }
 
     /** @return string[][] */
-    public function invalidUrlDataProvider(): array
+    public static function invalidUrlDataProvider(): array
     {
         return [
             ['http://'],
@@ -34,7 +35,7 @@ final class UrlTest extends TestCase
         ];
     }
 
-    /** @dataProvider invalidUrlDataProvider */
+    #[DataProvider('invalidUrlDataProvider')]
     public function testFromStringWillThrowExceptionForMalformedUrls(string $input): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -52,7 +53,7 @@ final class UrlTest extends TestCase
         self::assertTrue(Url::createFromString('https://api.host.com:8080/api-route?token=foo#bar')->equals($otherUrl));
     }
 
-    /** @dataProvider invalidEqualUrlProvider */
+    #[DataProvider('invalidEqualUrlProvider')]
     public function testEqualsWillReturnFalseIfObjectDoesNotMatch(Url $otherUrl): void
     {
         self::assertFalse(
@@ -61,7 +62,7 @@ final class UrlTest extends TestCase
     }
 
     /** @return Url[][] */
-    public function invalidEqualUrlProvider(): array
+    public static function invalidEqualUrlProvider(): array
     {
         return [
             [Url::createFromString('https://api.host.com')],

--- a/tests/benchmarks/Value/LocaleBench.php
+++ b/tests/benchmarks/Value/LocaleBench.php
@@ -11,11 +11,9 @@ use PhpBench\Benchmark\Metadata\Annotations\Revs;
 /** @BeforeMethods({"init"}) */
 final class LocaleBench
 {
-    /** @var Locale */
-    private $locale;
+    private Locale | null $locale = null;
 
-    /** @var Locale */
-    private $comparator;
+    private Locale | null $comparator = null;
 
     public function init(): void
     {

--- a/tests/benchmarks/Value/Web/DomainNameBench.php
+++ b/tests/benchmarks/Value/Web/DomainNameBench.php
@@ -10,11 +10,9 @@ use PhpBench\Benchmark\Metadata\Annotations\Revs;
 /** @BeforeMethods({"init"}) */
 final class DomainNameBench
 {
-    /** @var DomainName */
-    private $domainName;
+    private DomainName | null $domainName = null;
 
-    /** @var DomainName */
-    private $comparator;
+    private DomainName | null $comparator = null;
 
     public function init(): void
     {


### PR DESCRIPTION
Main points of attention: `ImmutableCollectionInterface`;
- `@implements \IteratorAggregate<TKey, T>` -> `@extends \IteratorAggregate<TKey, T>`
- `@implements \ArrayAccess<TKey, T>` -> `@extends \ArrayAccess<TKey, T>`

This change should help to resolve type information when iterating over collections.