### PR TITLE
chore: Changed Doctrine Annotation to Attribute

### DIFF
--- a/src/Value/Arithmetic/Amount.php
+++ b/src/Value/Arithmetic/Amount.php
@@ -3,22 +3,17 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Arithmetic;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use Litipk\BigNumbers\Decimal;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @ORM\Embeddable
- *
- * @psalm-immutable
- */
+/** @psalm-immutable */
+#[Embeddable]
 final class Amount extends Number
 {
-    /**
-     * @ORM\Column(name="amount", type="bignumbers", options={"doctrine_type"="bigint"})
-     *
-     * @var Decimal
-     */
+    /** @var Decimal */
+    #[Column(name: 'amount', type: 'bignumbers', options: ['doctrine_type' => 'bigint'])]
     protected $value;
 
     /**
@@ -28,7 +23,7 @@ final class Amount extends Number
      */
     public function __construct($value)
     {
-        if (\str_contains((string) $value, '.')) {
+        if (\str_contains((string)$value, '.')) {
             throw new InvalidArgument(\sprintf('Amount must be a whole number, "%s" given', $value));
         }
 

--- a/src/Value/Arithmetic/Percentage.php
+++ b/src/Value/Arithmetic/Percentage.php
@@ -7,9 +7,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class Percentage extends Number
 {

--- a/src/Value/Arithmetic/Percentage.php
+++ b/src/Value/Arithmetic/Percentage.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Arithmetic;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class Percentage extends Number
 {
     private function __construct(string $value, int | null $scale = null)

--- a/src/Value/Finance/Iban.php
+++ b/src/Value/Finance/Iban.php
@@ -8,15 +8,11 @@ use Doctrine\ORM\Mapping\Embeddable;
 use IsoCodes\Iban as IbanValidator;
 use MyOnlineStore\Common\Domain\Exception\Finance\InvalidIban;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class Iban
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(length: 24)]
     private $iban;
 

--- a/src/Value/Finance/Iban.php
+++ b/src/Value/Finance/Iban.php
@@ -3,22 +3,21 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Finance;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use IsoCodes\Iban as IbanValidator;
 use MyOnlineStore\Common\Domain\Exception\Finance\InvalidIban;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class Iban
 {
     /**
-     * @ORM\Column(length=24)
-     *
      * @var string
      */
+    #[Column(length: 24)]
     private $iban;
 
     /** @throws InvalidIban */

--- a/src/Value/LanguageCode.php
+++ b/src/Value/LanguageCode.php
@@ -2,23 +2,23 @@
 
 namespace MyOnlineStore\Common\Domain\Value;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * ISO 639 code (https://en.wikipedia.org/wiki/ISO_639)
  *
- * @ORM\Embeddable
  *
  * @psalm-immutable
  */
+#[Embeddable]
 final class LanguageCode
 {
     /**
-     * @ORM\Column(name="language_code", length=3)
-     *
      * @var string
      */
+    #[Column(name: 'language_code', length: 3)]
     private $code;
 
     /**

--- a/src/Value/LanguageCode.php
+++ b/src/Value/LanguageCode.php
@@ -9,15 +9,12 @@ use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 /**
  * ISO 639 code (https://en.wikipedia.org/wiki/ISO_639)
  *
- *
  * @psalm-immutable
  */
 #[Embeddable]
 final class LanguageCode
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(name: 'language_code', length: 3)]
     private $code;
 

--- a/src/Value/Locale.php
+++ b/src/Value/Locale.php
@@ -6,23 +6,17 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class Locale
 {
     public const FALLBACK_FRONTEND_LOCALE = 'en_GB';
 
-    /**
-     * @var RegionCode
-     */
+    /** @var RegionCode */
     #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\RegionCode', columnPrefix: false)]
     private $regionCode;
 
-    /**
-     * @var LanguageCode
-     */
+    /** @var LanguageCode */
     #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\LanguageCode', columnPrefix: false)]
     private $languageCode;
 

--- a/src/Value/Locale.php
+++ b/src/Value/Locale.php
@@ -2,30 +2,28 @@
 
 namespace MyOnlineStore\Common\Domain\Value;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class Locale
 {
     public const FALLBACK_FRONTEND_LOCALE = 'en_GB';
 
     /**
-     * @ORM\Embedded(class="MyOnlineStore\Common\Domain\Value\RegionCode", columnPrefix=false)
-     *
      * @var RegionCode
      */
+    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\RegionCode', columnPrefix: false)]
     private $regionCode;
 
     /**
-     * @ORM\Embedded(class="MyOnlineStore\Common\Domain\Value\LanguageCode", columnPrefix=false)
-     *
      * @var LanguageCode
      */
+    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\LanguageCode', columnPrefix: false)]
     private $languageCode;
 
     public function __construct(LanguageCode $languageCode, RegionCode $regionCode)

--- a/src/Value/Location/Address/City.php
+++ b/src/Value/Location/Address/City.php
@@ -3,22 +3,21 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class City
 {
     /**
-     * @ORM\Column(name="city")
-     *
      * @var string
      */
+    #[Column(name: 'city')]
     private $city;
 
     private function __construct(string $city)

--- a/src/Value/Location/Address/Street.php
+++ b/src/Value/Location/Address/Street.php
@@ -7,9 +7,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class Street
 {
@@ -18,21 +16,15 @@ final class Street
         '/^(?P<number>\d+)(?P<suffix>\w*)\s+(?P<street>.*)$/',
     ];
 
-    /**
-     * @var StreetName
-     */
+    /** @var StreetName */
     #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Location\Address\StreetName', columnPrefix: false)]
     private $name;
 
-    /**
-     * @var StreetNumber
-     */
+    /** @var StreetNumber */
     #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Location\Address\StreetNumber', columnPrefix: false)]
     private $number;
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     #[Column(name: 'street_suffix', nullable: true)]
     private $suffix;
 

--- a/src/Value/Location/Address/Street.php
+++ b/src/Value/Location/Address/Street.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class Street
 {
     private const SINGLE_LINE_PATTERNS = [
@@ -19,24 +19,21 @@ final class Street
     ];
 
     /**
-     * @ORM\Embedded(class="MyOnlineStore\Common\Domain\Value\Location\Address\StreetName", columnPrefix=false)
-     *
      * @var StreetName
      */
+    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Location\Address\StreetName', columnPrefix: false)]
     private $name;
 
     /**
-     * @ORM\Embedded(class="MyOnlineStore\Common\Domain\Value\Location\Address\StreetNumber", columnPrefix=false)
-     *
      * @var StreetNumber
      */
+    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Location\Address\StreetNumber', columnPrefix: false)]
     private $number;
 
     /**
-     * @ORM\Column(name="street_suffix", nullable=true)
-     *
      * @var string|null
      */
+    #[Column(name: 'street_suffix', nullable: true)]
     private $suffix;
 
     public function __construct(StreetName $name, StreetNumber $number, StreetSuffix | null $suffix = null)

--- a/src/Value/Location/Address/StreetName.php
+++ b/src/Value/Location/Address/StreetName.php
@@ -8,15 +8,11 @@ use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class StreetName
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(name: 'street_name')]
     private $name;
 

--- a/src/Value/Location/Address/StreetName.php
+++ b/src/Value/Location/Address/StreetName.php
@@ -3,22 +3,21 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class StreetName
 {
     /**
-     * @ORM\Column(name="street_name")
-     *
      * @var string
      */
+    #[Column(name: 'street_name')]
     private $name;
 
     private function __construct(string $name)

--- a/src/Value/Location/Address/StreetNumber.php
+++ b/src/Value/Location/Address/StreetNumber.php
@@ -3,22 +3,21 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class StreetNumber
 {
     /**
-     * @ORM\Column(name="street_number")
-     *
      * @var string
      */
+    #[Column(name: 'street_number')]
     private $number;
 
     private function __construct(string $number)

--- a/src/Value/Location/Address/StreetNumber.php
+++ b/src/Value/Location/Address/StreetNumber.php
@@ -8,15 +8,11 @@ use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class StreetNumber
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(name: 'street_number')]
     private $number;
 

--- a/src/Value/Location/Address/ZipCode.php
+++ b/src/Value/Location/Address/ZipCode.php
@@ -8,18 +8,14 @@ use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class ZipCode
 {
     // not all countries use zipCodes, see SCS-417 and https://gist.github.com/kennwilson/3902548
     private const NOT_AVAILABLE = 'N/A';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(name: 'zip_code', length: 10)]
     private $zipCode;
 

--- a/src/Value/Location/Address/ZipCode.php
+++ b/src/Value/Location/Address/ZipCode.php
@@ -3,25 +3,24 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class ZipCode
 {
     // not all countries use zipCodes, see SCS-417 and https://gist.github.com/kennwilson/3902548
     private const NOT_AVAILABLE = 'N/A';
 
     /**
-     * @ORM\Column(name="zip_code", length=10)
-     *
      * @var string
      */
+    #[Column(name: 'zip_code', length: 10)]
     private $zipCode;
 
     private function __construct(string $zipCode)

--- a/src/Value/Mail/EmailAddress.php
+++ b/src/Value/Mail/EmailAddress.php
@@ -3,23 +3,22 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Mail;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Validation\RFCValidation;
 use MyOnlineStore\Common\Domain\Exception\Mail\InvalidEmailAddress;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class EmailAddress
 {
     /**
-     * @ORM\Column(name="email_address")
-     *
      * @var string
      */
+    #[Column(name: 'email_address')]
     private $emailAddress;
 
     /** @throws InvalidEmailAddress */

--- a/src/Value/Mail/EmailAddress.php
+++ b/src/Value/Mail/EmailAddress.php
@@ -9,15 +9,11 @@ use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Validation\RFCValidation;
 use MyOnlineStore\Common\Domain\Exception\Mail\InvalidEmailAddress;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class EmailAddress
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(name: 'email_address')]
     private $emailAddress;
 

--- a/src/Value/Money/CurrencyIso.php
+++ b/src/Value/Money/CurrencyIso.php
@@ -7,9 +7,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\Currency\InvalidCurrencyIso;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class CurrencyIso
 {

--- a/src/Value/Money/CurrencyIso.php
+++ b/src/Value/Money/CurrencyIso.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Money;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\Currency\InvalidCurrencyIso;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class CurrencyIso
 {
     private const CURRENCIES =  [
@@ -1270,10 +1270,9 @@ final class CurrencyIso
     ];
 
     /**
-     * @ORM\Column(name="currency", length=3)
-     *
      * @var string
      */
+    #[Column(name: 'currency', length: 3)]
     private $currency;
 
     private function __construct(string $currency)

--- a/src/Value/Money/Money.php
+++ b/src/Value/Money/Money.php
@@ -3,28 +3,26 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Money;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Value\Arithmetic\Amount;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class Money
 {
     /**
-     * @ORM\Embedded(class="MyOnlineStore\Common\Domain\Value\Arithmetic\Amount", columnPrefix=false)
-     *
      * @var Amount
      */
+    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Arithmetic\Amount', columnPrefix: false)]
     private $amount;
 
     /**
-     * @ORM\Embedded(class="MyOnlineStore\Common\Domain\Value\Money\CurrencyIso", columnPrefix=false)
-     *
      * @var CurrencyIso
      */
+    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Money\CurrencyIso', columnPrefix: false)]
     private $currency;
 
     public function __construct(Amount $amount, CurrencyIso $currency)

--- a/src/Value/Money/Money.php
+++ b/src/Value/Money/Money.php
@@ -7,21 +7,15 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Value\Arithmetic\Amount;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class Money
 {
-    /**
-     * @var Amount
-     */
+    /** @var Amount */
     #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Arithmetic\Amount', columnPrefix: false)]
     private $amount;
 
-    /**
-     * @var CurrencyIso
-     */
+    /** @var CurrencyIso */
     #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Money\CurrencyIso', columnPrefix: false)]
     private $currency;
 

--- a/src/Value/Money/Price.php
+++ b/src/Value/Money/Price.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Money;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Value\Arithmetic\Amount;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class Price
 {
     public const PRECISION_CALC = 6;
@@ -18,12 +18,11 @@ final class Price
     public const PRECISION_INTERMEDIATE = 7;
 
     /**
-     * @ORM\Column(name="price", type="decimal", precision=15, scale=6)
      *
      * @var string
-     *
      * @psalm-var numeric-string
      */
+    #[Column(name: 'price', type: 'decimal', precision: 15, scale: 6)]
     private $amount;
 
     /** @param float|int|string $amount */

--- a/src/Value/Money/Price.php
+++ b/src/Value/Money/Price.php
@@ -7,9 +7,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Value\Arithmetic\Amount;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class Price
 {
@@ -18,7 +16,6 @@ final class Price
     public const PRECISION_INTERMEDIATE = 7;
 
     /**
-     *
      * @var string
      * @psalm-var numeric-string
      */

--- a/src/Value/Person/BirthDate.php
+++ b/src/Value/Person/BirthDate.php
@@ -3,18 +3,16 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Person;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 
-/**
- * @ORM\Embeddable
- *
- * @psalm-immutable
- */
+/** @psalm-immutable */
+#[Embeddable]
 final class BirthDate
 {
     private const FORMAT = 'Y-m-d';
 
-    /** @ORM\Column(name="birth_date", type="date_immutable") */
+    #[Column(name: 'birth_date', type: 'date_immutable')]
     private \DateTimeImmutable $date;
 
     private function __construct(\DateTimeImmutable $date)

--- a/src/Value/Person/Gender.php
+++ b/src/Value/Person/Gender.php
@@ -3,24 +3,23 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Person;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\Person\InvalidGender;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class Gender
 {
     private const MALE = 'M';
     private const FEMALE = 'F';
 
     /**
-     * @ORM\Column(name="gender", length=1)
-     *
      * @var string
      */
+    #[Column(name: 'gender', length: 1)]
     private $gender;
 
     private function __construct(string $gender)

--- a/src/Value/Person/Gender.php
+++ b/src/Value/Person/Gender.php
@@ -7,18 +7,14 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\Person\InvalidGender;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class Gender
 {
     private const MALE = 'M';
     private const FEMALE = 'F';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(name: 'gender', length: 1)]
     private $gender;
 

--- a/src/Value/Person/Name.php
+++ b/src/Value/Person/Name.php
@@ -3,29 +3,27 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Person;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Value\Person\Name\FirstName;
 use MyOnlineStore\Common\Domain\Value\Person\Name\LastName;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class Name
 {
     /**
-     * @ORM\Embedded(class="MyOnlineStore\Common\Domain\Value\Person\Name\FirstName", columnPrefix=false)
-     *
      * @var FirstName
      */
+    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Person\Name\FirstName', columnPrefix: false)]
     private $firstName;
 
     /**
-     * @ORM\Embedded(class="MyOnlineStore\Common\Domain\Value\Person\Name\LastName", columnPrefix=false)
-     *
      * @var LastName
      */
+    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Person\Name\LastName', columnPrefix: false)]
     private $lastName;
 
     public function __construct(FirstName $first, LastName $last)

--- a/src/Value/Person/Name/FirstName.php
+++ b/src/Value/Person/Name/FirstName.php
@@ -8,15 +8,11 @@ use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class FirstName
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(name: 'first_name')]
     private $firstName;
 

--- a/src/Value/Person/Name/FirstName.php
+++ b/src/Value/Person/Name/FirstName.php
@@ -3,22 +3,21 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Person\Name;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class FirstName
 {
     /**
-     * @ORM\Column(name="first_name")
-     *
      * @var string
      */
+    #[Column(name: 'first_name')]
     private $firstName;
 
     private function __construct(string $firstName)

--- a/src/Value/Person/Name/LastName.php
+++ b/src/Value/Person/Name/LastName.php
@@ -3,22 +3,21 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Person\Name;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class LastName
 {
     /**
-     * @ORM\Column(name="last_name")
-     *
      * @var string
      */
+    #[Column(name: 'last_name')]
     private $lastName;
 
     private function __construct(string $lastName)

--- a/src/Value/RegionCode.php
+++ b/src/Value/RegionCode.php
@@ -15,9 +15,7 @@ use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 #[Embeddable]
 final class RegionCode
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(name: 'region_code', type: 'string', length: 2)]
     private $code;
 

--- a/src/Value/RegionCode.php
+++ b/src/Value/RegionCode.php
@@ -3,23 +3,22 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * ISO 3166-1 alpha-2 code (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
  *
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class RegionCode
 {
     /**
-     * @ORM\Column(name="region_code", type="string", length=2)
-     *
      * @var string
      */
+    #[Column(name: 'region_code', type: 'string', length: 2)]
     private $code;
 
     /**

--- a/src/Value/StoreId.php
+++ b/src/Value/StoreId.php
@@ -5,15 +5,11 @@ namespace MyOnlineStore\Common\Domain\Value;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class StoreId
 {
-    /**
-     * @var int|string
-     */
+    /** @var int|string */
     #[Column(name: 'store_id', type: 'integer')]
     private $id;
 

--- a/src/Value/StoreId.php
+++ b/src/Value/StoreId.php
@@ -2,20 +2,19 @@
 
 namespace MyOnlineStore\Common\Domain\Value;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class StoreId
 {
     /**
-     * @ORM\Column(name="store_id", type="integer")
-     *
      * @var int|string
      */
+    #[Column(name: 'store_id', type: 'integer')]
     private $id;
 
     /** @param int|string $id */

--- a/src/Value/Web/IPAddress.php
+++ b/src/Value/Web/IPAddress.php
@@ -6,15 +6,11 @@ namespace MyOnlineStore\Common\Domain\Value\Web;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class IPAddress
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(name: 'ip_address', length: 39)]
     private $value;
 

--- a/src/Value/Web/IPAddress.php
+++ b/src/Value/Web/IPAddress.php
@@ -3,20 +3,19 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Web;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class IPAddress
 {
     /**
-     * @ORM\Column(name="ip_address", length=39)
-     *
      * @var string
      */
+    #[Column(name: 'ip_address', length: 39)]
     private $value;
 
     /**

--- a/src/Value/Web/ViewPort.php
+++ b/src/Value/Web/ViewPort.php
@@ -5,11 +5,10 @@ namespace MyOnlineStore\Common\Domain\Value\Web;
 
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
+use Doctrine\ORM\Mapping\Id;
 use MyOnlineStore\Common\Domain\Assertion\EnumValueGuardTrait;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class ViewPort
 {
@@ -19,10 +18,7 @@ final class ViewPort
     const MEDIUM = 'medium';
     const LARGE = 'large';
 
-    /**
-     *
-     * @var string
-     */
+    /** @var string */
     #[Id]
     #[Column(type: 'string', name: 'viewport')]
     private $value;

--- a/src/Value/Web/ViewPort.php
+++ b/src/Value/Web/ViewPort.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Web;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\EnumValueGuardTrait;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class ViewPort
 {
     use EnumValueGuardTrait;
@@ -20,11 +20,11 @@ final class ViewPort
     const LARGE = 'large';
 
     /**
-     * @ORM\Id
-     * @ORM\Column(type="string", name="viewport")
      *
      * @var string
      */
+    #[Id]
+    #[Column(type: 'string', name: 'viewport')]
     private $value;
 
     /**


### PR DESCRIPTION
## Summary 🌟
This changes the deprecated annotation docblocks to attribute. Used rector to change the blocks and then rearranged the comments there were needed manually.

## Technical choices ⚙️

- Introduced `3.x-dev` branch due to Doctrine `3.x` [not being BC](https://github.com/doctrine/orm/blob/3.0.x/UPGRADE.md).
- Used rector's `DoctrineSetList::ANNOTATIONS_TO_ATTRIBUTES` as-per [upgrade guide](https://www.doctrine-project.org/2022/11/04/annotations-to-attributes.html).

## Testing instructions 📚
You can test this PR by following these steps:

1. You can use `myparcel-shipment-logger` to test this PR as it's using the attribute driver.