### PR TITLE
chore: Changed Doctrine Annotation to Attribute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test
 
 on:
     push:
@@ -10,14 +10,11 @@ on:
 jobs:
     test:
         name: Test
-
-        runs-on: ubuntu-18.04
-
+        runs-on: ubuntu-latest
         strategy:
             matrix:
                 php-version: ['8.1']
             fail-fast: false
-
         steps:
             # Setup
             -   name: Checkout
@@ -40,8 +37,8 @@ jobs:
                 run: composer install --no-ansi --no-interaction --no-progress --no-suggest
 
             # Test
-#            -   name: Codestyle
-#                run: php vendor/bin/phpcs -q --report=checkstyle | cs2pr
+            -   name: Codestyle
+                run: php vendor/bin/phpcs -q --report=checkstyle | cs2pr
             -   name: PHPUnit Checks Matcher
                 run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
             -   name: Unit Tests
@@ -51,27 +48,3 @@ jobs:
                     echo "COVERAGE=${COVERAGE}" >> $GITHUB_ENV
             -   name: Run Psalm
                 run: vendor/bin/psalm --output-format=github
-
-            # Compare to master
-#            -   name: Checkout Master
-#                uses: actions/checkout@v2
-#                with:
-#                    ref: master
-#            -   name: Install Dependencies Master
-#                run: composer install --no-interaction --no-ansi --no-progress --no-suggest
-#            -   name: Unit Tests Master
-#                run: |
-#                    php vendor/bin/phpunit --coverage-text=coverage-master.txt --colors=never
-#                    COVERAGE_MASTER=$(php -r 'preg_match("#Lines:\s*(\d+.\d+)%#", file_get_contents("coverage-master.txt"), $out); echo $out[1];')
-#                    echo "COVERAGE_MASTER=${COVERAGE_MASTER}" >> $GITHUB_ENV
-#            -   name: Report PR Status
-#                uses: actions/github-script@0.6.0
-#                with:
-#                    github-token: ${{github.token}}
-#                    script: |
-#                        const coverage = parseFloat(process.env.COVERAGE);
-#                        const coverageMaster = parseFloat(process.env.COVERAGE_MASTER);
-#                        const coverageChange = (coverage - coverageMaster).toFixed(2);
-#
-#                        github.repos.createStatus({...context.repo, sha: context.sha, state: coverage > 98 ? 'success' : 'failure', context: 'Unit Test Coverage', description: coverage+'%'});
-#                        github.repos.createStatus({...context.repo, sha: context.sha, state: coverageChange < 0 ? 'failure' : 'success', context: 'Unit Test Coverage Change', description: coverageChange+'%'});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
                 run: composer install --no-ansi --no-interaction --no-progress --no-suggest
 
             # Test
-            -   name: Codestyle
-                run: php vendor/bin/phpcs -q --report=checkstyle | cs2pr
+#            -   name: Codestyle
+#                run: php vendor/bin/phpcs -q --report=checkstyle | cs2pr
             -   name: PHPUnit Checks Matcher
                 run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
             -   name: Unit Tests

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,23 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="vendor/autoload.php"
-         colors="true"
-         cacheDirectory=".phpunit.cache"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
->
-    <coverage includeUncoveredFiles="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <source>
         <include>
             <directory suffix=".php">src</directory>
         </include>
         <exclude>
             <file>src/Assertion/Assert.php</file>
         </exclude>
-    </coverage>
-
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
+    </source>
 </phpunit>

--- a/src/Collection/ImmutableCollection.php
+++ b/src/Collection/ImmutableCollection.php
@@ -16,7 +16,7 @@ class ImmutableCollection extends MutableCollection
         throw new \LogicException(\sprintf('Method %s is not available on immutable collections', __FUNCTION__));
     }
 
-    public function offsetSet(mixed $key, mixed $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         throw new \LogicException(\sprintf('Method %s is not available on immutable collections', __FUNCTION__));
     }

--- a/src/Value/Arithmetic/Amount.php
+++ b/src/Value/Arithmetic/Amount.php
@@ -3,22 +3,17 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Arithmetic;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use Litipk\BigNumbers\Decimal;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @ORM\Embeddable
- *
- * @psalm-immutable
- */
+/** @psalm-immutable */
+#[Embeddable]
 final class Amount extends Number
 {
-    /**
-     * @ORM\Column(name="amount", type="bignumbers", options={"doctrine_type"="bigint"})
-     *
-     * @var Decimal
-     */
+    /** @var Decimal */
+    #[Column(name: 'amount', type: 'bignumbers', options: ['doctrine_type' => 'bigint'])]
     protected $value;
 
     /**
@@ -28,7 +23,7 @@ final class Amount extends Number
      */
     public function __construct($value)
     {
-        if (\str_contains((string) $value, '.')) {
+        if (\str_contains((string)$value, '.')) {
             throw new InvalidArgument(\sprintf('Amount must be a whole number, "%s" given', $value));
         }
 

--- a/src/Value/Arithmetic/Percentage.php
+++ b/src/Value/Arithmetic/Percentage.php
@@ -7,9 +7,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class Percentage extends Number
 {

--- a/src/Value/Arithmetic/Percentage.php
+++ b/src/Value/Arithmetic/Percentage.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Arithmetic;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class Percentage extends Number
 {
     private function __construct(string $value, int | null $scale = null)

--- a/src/Value/Finance/Iban.php
+++ b/src/Value/Finance/Iban.php
@@ -8,15 +8,11 @@ use Doctrine\ORM\Mapping\Embeddable;
 use IsoCodes\Iban as IbanValidator;
 use MyOnlineStore\Common\Domain\Exception\Finance\InvalidIban;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class Iban
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(length: 24)]
     private $iban;
 

--- a/src/Value/Finance/Iban.php
+++ b/src/Value/Finance/Iban.php
@@ -3,22 +3,21 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Finance;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use IsoCodes\Iban as IbanValidator;
 use MyOnlineStore\Common\Domain\Exception\Finance\InvalidIban;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class Iban
 {
     /**
-     * @ORM\Column(length=24)
-     *
      * @var string
      */
+    #[Column(length: 24)]
     private $iban;
 
     /** @throws InvalidIban */

--- a/src/Value/LanguageCode.php
+++ b/src/Value/LanguageCode.php
@@ -2,23 +2,23 @@
 
 namespace MyOnlineStore\Common\Domain\Value;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * ISO 639 code (https://en.wikipedia.org/wiki/ISO_639)
  *
- * @ORM\Embeddable
  *
  * @psalm-immutable
  */
+#[Embeddable]
 final class LanguageCode
 {
     /**
-     * @ORM\Column(name="language_code", length=3)
-     *
      * @var string
      */
+    #[Column(name: 'language_code', length: 3)]
     private $code;
 
     /**

--- a/src/Value/LanguageCode.php
+++ b/src/Value/LanguageCode.php
@@ -9,15 +9,12 @@ use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 /**
  * ISO 639 code (https://en.wikipedia.org/wiki/ISO_639)
  *
- *
  * @psalm-immutable
  */
 #[Embeddable]
 final class LanguageCode
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(name: 'language_code', length: 3)]
     private $code;
 

--- a/src/Value/Locale.php
+++ b/src/Value/Locale.php
@@ -6,23 +6,17 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class Locale
 {
     public const FALLBACK_FRONTEND_LOCALE = 'en_GB';
 
-    /**
-     * @var RegionCode
-     */
+    /** @var RegionCode */
     #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\RegionCode', columnPrefix: false)]
     private $regionCode;
 
-    /**
-     * @var LanguageCode
-     */
+    /** @var LanguageCode */
     #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\LanguageCode', columnPrefix: false)]
     private $languageCode;
 

--- a/src/Value/Locale.php
+++ b/src/Value/Locale.php
@@ -4,6 +4,7 @@ namespace MyOnlineStore\Common\Domain\Value;
 
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
+use Doctrine\ORM\Mapping\Embedded;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /** @psalm-immutable */
@@ -13,11 +14,11 @@ final class Locale
     public const FALLBACK_FRONTEND_LOCALE = 'en_GB';
 
     /** @var RegionCode */
-    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\RegionCode', columnPrefix: false)]
+    #[Embedded(class: RegionCode::class, columnPrefix: false)]
     private $regionCode;
 
     /** @var LanguageCode */
-    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\LanguageCode', columnPrefix: false)]
+    #[Embedded(class: LanguageCode::class, columnPrefix: false)]
     private $languageCode;
 
     public function __construct(LanguageCode $languageCode, RegionCode $regionCode)

--- a/src/Value/Locale.php
+++ b/src/Value/Locale.php
@@ -2,30 +2,28 @@
 
 namespace MyOnlineStore\Common\Domain\Value;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class Locale
 {
     public const FALLBACK_FRONTEND_LOCALE = 'en_GB';
 
     /**
-     * @ORM\Embedded(class="MyOnlineStore\Common\Domain\Value\RegionCode", columnPrefix=false)
-     *
      * @var RegionCode
      */
+    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\RegionCode', columnPrefix: false)]
     private $regionCode;
 
     /**
-     * @ORM\Embedded(class="MyOnlineStore\Common\Domain\Value\LanguageCode", columnPrefix=false)
-     *
      * @var LanguageCode
      */
+    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\LanguageCode', columnPrefix: false)]
     private $languageCode;
 
     public function __construct(LanguageCode $languageCode, RegionCode $regionCode)

--- a/src/Value/Location/Address/City.php
+++ b/src/Value/Location/Address/City.php
@@ -3,22 +3,21 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class City
 {
     /**
-     * @ORM\Column(name="city")
-     *
      * @var string
      */
+    #[Column(name: 'city')]
     private $city;
 
     private function __construct(string $city)

--- a/src/Value/Location/Address/Street.php
+++ b/src/Value/Location/Address/Street.php
@@ -7,9 +7,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class Street
 {
@@ -18,21 +16,15 @@ final class Street
         '/^(?P<number>\d+)(?P<suffix>\w*)\s+(?P<street>.*)$/',
     ];
 
-    /**
-     * @var StreetName
-     */
+    /** @var StreetName */
     #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Location\Address\StreetName', columnPrefix: false)]
     private $name;
 
-    /**
-     * @var StreetNumber
-     */
+    /** @var StreetNumber */
     #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Location\Address\StreetNumber', columnPrefix: false)]
     private $number;
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     #[Column(name: 'street_suffix', nullable: true)]
     private $suffix;
 

--- a/src/Value/Location/Address/Street.php
+++ b/src/Value/Location/Address/Street.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class Street
 {
     private const SINGLE_LINE_PATTERNS = [
@@ -19,24 +19,21 @@ final class Street
     ];
 
     /**
-     * @ORM\Embedded(class="MyOnlineStore\Common\Domain\Value\Location\Address\StreetName", columnPrefix=false)
-     *
      * @var StreetName
      */
+    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Location\Address\StreetName', columnPrefix: false)]
     private $name;
 
     /**
-     * @ORM\Embedded(class="MyOnlineStore\Common\Domain\Value\Location\Address\StreetNumber", columnPrefix=false)
-     *
      * @var StreetNumber
      */
+    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Location\Address\StreetNumber', columnPrefix: false)]
     private $number;
 
     /**
-     * @ORM\Column(name="street_suffix", nullable=true)
-     *
      * @var string|null
      */
+    #[Column(name: 'street_suffix', nullable: true)]
     private $suffix;
 
     public function __construct(StreetName $name, StreetNumber $number, StreetSuffix | null $suffix = null)

--- a/src/Value/Location/Address/Street.php
+++ b/src/Value/Location/Address/Street.php
@@ -5,6 +5,7 @@ namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
+use Doctrine\ORM\Mapping\Embedded;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /** @psalm-immutable */
@@ -57,6 +58,7 @@ final class Street
 
     public function equals(self $operand): bool
     {
+        /** @palm-supress RiskyTruthyFalsyComparison */
         return $this->name->equals($operand->name) &&
             $this->number->equals($operand->number) &&
             $this->suffix === $operand->suffix;
@@ -79,6 +81,7 @@ final class Street
 
     public function __toString(): string
     {
+        /** @palm-supress RiskyTruthyFalsyComparison */
         return \trim(\sprintf('%s %s %s', $this->name, $this->number, $this->suffix ?: ''));
     }
 }

--- a/src/Value/Location/Address/Street.php
+++ b/src/Value/Location/Address/Street.php
@@ -18,11 +18,11 @@ final class Street
     ];
 
     /** @var StreetName */
-    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Location\Address\StreetName', columnPrefix: false)]
+    #[Embedded(class: StreetName::class, columnPrefix: false)]
     private $name;
 
     /** @var StreetNumber */
-    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Location\Address\StreetNumber', columnPrefix: false)]
+    #[Embedded(class: StreetNumber::class, columnPrefix: false)]
     private $number;
 
     /** @var string|null */
@@ -58,7 +58,7 @@ final class Street
 
     public function equals(self $operand): bool
     {
-        /** @palm-supress RiskyTruthyFalsyComparison */
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         return $this->name->equals($operand->name) &&
             $this->number->equals($operand->number) &&
             $this->suffix === $operand->suffix;
@@ -76,12 +76,13 @@ final class Street
 
     public function getSuffix(): StreetSuffix | null
     {
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         return $this->suffix ? StreetSuffix::fromString($this->suffix) : null;
     }
 
     public function __toString(): string
     {
-        /** @palm-supress RiskyTruthyFalsyComparison */
+        /** @psalm-suppress RiskyTruthyFalsyComparison */
         return \trim(\sprintf('%s %s %s', $this->name, $this->number, $this->suffix ?: ''));
     }
 }

--- a/src/Value/Location/Address/StreetName.php
+++ b/src/Value/Location/Address/StreetName.php
@@ -8,15 +8,11 @@ use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class StreetName
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(name: 'street_name')]
     private $name;
 

--- a/src/Value/Location/Address/StreetName.php
+++ b/src/Value/Location/Address/StreetName.php
@@ -3,22 +3,21 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class StreetName
 {
     /**
-     * @ORM\Column(name="street_name")
-     *
      * @var string
      */
+    #[Column(name: 'street_name')]
     private $name;
 
     private function __construct(string $name)

--- a/src/Value/Location/Address/StreetNumber.php
+++ b/src/Value/Location/Address/StreetNumber.php
@@ -3,22 +3,21 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class StreetNumber
 {
     /**
-     * @ORM\Column(name="street_number")
-     *
      * @var string
      */
+    #[Column(name: 'street_number')]
     private $number;
 
     private function __construct(string $number)

--- a/src/Value/Location/Address/StreetNumber.php
+++ b/src/Value/Location/Address/StreetNumber.php
@@ -8,15 +8,11 @@ use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class StreetNumber
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(name: 'street_number')]
     private $number;
 

--- a/src/Value/Location/Address/ZipCode.php
+++ b/src/Value/Location/Address/ZipCode.php
@@ -8,18 +8,14 @@ use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class ZipCode
 {
     // not all countries use zipCodes, see SCS-417 and https://gist.github.com/kennwilson/3902548
     private const NOT_AVAILABLE = 'N/A';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(name: 'zip_code', length: 10)]
     private $zipCode;
 

--- a/src/Value/Location/Address/ZipCode.php
+++ b/src/Value/Location/Address/ZipCode.php
@@ -3,25 +3,24 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Location\Address;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class ZipCode
 {
     // not all countries use zipCodes, see SCS-417 and https://gist.github.com/kennwilson/3902548
     private const NOT_AVAILABLE = 'N/A';
 
     /**
-     * @ORM\Column(name="zip_code", length=10)
-     *
      * @var string
      */
+    #[Column(name: 'zip_code', length: 10)]
     private $zipCode;
 
     private function __construct(string $zipCode)

--- a/src/Value/Mail/EmailAddress.php
+++ b/src/Value/Mail/EmailAddress.php
@@ -3,23 +3,22 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Mail;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Validation\RFCValidation;
 use MyOnlineStore\Common\Domain\Exception\Mail\InvalidEmailAddress;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class EmailAddress
 {
     /**
-     * @ORM\Column(name="email_address")
-     *
      * @var string
      */
+    #[Column(name: 'email_address')]
     private $emailAddress;
 
     /** @throws InvalidEmailAddress */

--- a/src/Value/Mail/EmailAddress.php
+++ b/src/Value/Mail/EmailAddress.php
@@ -9,15 +9,11 @@ use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Validation\RFCValidation;
 use MyOnlineStore\Common\Domain\Exception\Mail\InvalidEmailAddress;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class EmailAddress
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(name: 'email_address')]
     private $emailAddress;
 

--- a/src/Value/Money/CurrencyIso.php
+++ b/src/Value/Money/CurrencyIso.php
@@ -7,9 +7,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\Currency\InvalidCurrencyIso;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class CurrencyIso
 {

--- a/src/Value/Money/CurrencyIso.php
+++ b/src/Value/Money/CurrencyIso.php
@@ -3,12 +3,14 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Money;
 
-use Doctrine\ORM\Mapping\Column;
-use Doctrine\ORM\Mapping\Embeddable;
+use Doctrine\ORM\Mapping as ORM;
 use MyOnlineStore\Common\Domain\Exception\Currency\InvalidCurrencyIso;
 
-/** @psalm-immutable */
-#[Embeddable]
+/**
+ * @ORM\Embeddable
+ *
+ * @psalm-immutable
+ */
 final class CurrencyIso
 {
     private const CURRENCIES =  [
@@ -937,11 +939,18 @@ final class CurrencyIso
                  'numericCode' => 690,
              ],
         'SLL' =>
+            [
+                'alphabeticCode' => 'SLL',
+                'currency' => 'Leone',
+                'minorUnit' => 2,
+                'numericCode' => 694,
+            ],
+        'SLE' =>
              [
-                 'alphabeticCode' => 'SLL',
+                 'alphabeticCode' => 'SLE',
                  'currency' => 'Leone',
                  'minorUnit' => 2,
-                 'numericCode' => 694,
+                 'numericCode' => 925,
              ],
         'SGD' =>
              [
@@ -1268,9 +1277,10 @@ final class CurrencyIso
     ];
 
     /**
+     * @ORM\Column(name="currency", length=3)
+     *
      * @var string
      */
-    #[Column(name: 'currency', length: 3)]
     private $currency;
 
     private function __construct(string $currency)

--- a/src/Value/Money/CurrencyIso.php
+++ b/src/Value/Money/CurrencyIso.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Money;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\Currency\InvalidCurrencyIso;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class CurrencyIso
 {
     private const CURRENCIES =  [
@@ -1270,10 +1270,9 @@ final class CurrencyIso
     ];
 
     /**
-     * @ORM\Column(name="currency", length=3)
-     *
      * @var string
      */
+    #[Column(name: 'currency', length: 3)]
     private $currency;
 
     private function __construct(string $currency)

--- a/src/Value/Money/CurrencyIso.php
+++ b/src/Value/Money/CurrencyIso.php
@@ -1169,6 +1169,13 @@ final class CurrencyIso
                  'minorUnit' => 0,
                  'numericCode' => 548,
              ],
+        'VED' =>
+             [
+                 'alphabeticCode' => 'VED',
+                 'currency' => 'Bolívar Soberano',
+                 'minorUnit' => 2,
+                 'numericCode' => 926,
+             ],
         'VES' =>
              [
                  'alphabeticCode' => 'VES',

--- a/src/Value/Money/Money.php
+++ b/src/Value/Money/Money.php
@@ -5,6 +5,7 @@ namespace MyOnlineStore\Common\Domain\Value\Money;
 
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
+use Doctrine\ORM\Mapping\Embedded;
 use MyOnlineStore\Common\Domain\Value\Arithmetic\Amount;
 
 /** @psalm-immutable */

--- a/src/Value/Money/Money.php
+++ b/src/Value/Money/Money.php
@@ -3,28 +3,26 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Money;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Value\Arithmetic\Amount;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class Money
 {
     /**
-     * @ORM\Embedded(class="MyOnlineStore\Common\Domain\Value\Arithmetic\Amount", columnPrefix=false)
-     *
      * @var Amount
      */
+    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Arithmetic\Amount', columnPrefix: false)]
     private $amount;
 
     /**
-     * @ORM\Embedded(class="MyOnlineStore\Common\Domain\Value\Money\CurrencyIso", columnPrefix=false)
-     *
      * @var CurrencyIso
      */
+    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Money\CurrencyIso', columnPrefix: false)]
     private $currency;
 
     public function __construct(Amount $amount, CurrencyIso $currency)

--- a/src/Value/Money/Money.php
+++ b/src/Value/Money/Money.php
@@ -7,21 +7,15 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Value\Arithmetic\Amount;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class Money
 {
-    /**
-     * @var Amount
-     */
+    /** @var Amount */
     #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Arithmetic\Amount', columnPrefix: false)]
     private $amount;
 
-    /**
-     * @var CurrencyIso
-     */
+    /** @var CurrencyIso */
     #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Money\CurrencyIso', columnPrefix: false)]
     private $currency;
 

--- a/src/Value/Money/Money.php
+++ b/src/Value/Money/Money.php
@@ -13,11 +13,11 @@ use MyOnlineStore\Common\Domain\Value\Arithmetic\Amount;
 final class Money
 {
     /** @var Amount */
-    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Arithmetic\Amount', columnPrefix: false)]
+    #[Embedded(class: Amount::class, columnPrefix: false)]
     private $amount;
 
     /** @var CurrencyIso */
-    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Money\CurrencyIso', columnPrefix: false)]
+    #[Embedded(class: CurrencyIso::class, columnPrefix: false)]
     private $currency;
 
     public function __construct(Amount $amount, CurrencyIso $currency)

--- a/src/Value/Money/Price.php
+++ b/src/Value/Money/Price.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Money;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Value\Arithmetic\Amount;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class Price
 {
     public const PRECISION_CALC = 6;
@@ -18,12 +18,11 @@ final class Price
     public const PRECISION_INTERMEDIATE = 7;
 
     /**
-     * @ORM\Column(name="price", type="decimal", precision=15, scale=6)
      *
      * @var string
-     *
      * @psalm-var numeric-string
      */
+    #[Column(name: 'price', type: 'decimal', precision: 15, scale: 6)]
     private $amount;
 
     /** @param float|int|string $amount */

--- a/src/Value/Money/Price.php
+++ b/src/Value/Money/Price.php
@@ -7,9 +7,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Value\Arithmetic\Amount;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class Price
 {
@@ -18,7 +16,6 @@ final class Price
     public const PRECISION_INTERMEDIATE = 7;
 
     /**
-     *
      * @var string
      * @psalm-var numeric-string
      */

--- a/src/Value/Person/BirthDate.php
+++ b/src/Value/Person/BirthDate.php
@@ -3,18 +3,16 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Person;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 
-/**
- * @ORM\Embeddable
- *
- * @psalm-immutable
- */
+/** @psalm-immutable */
+#[Embeddable]
 final class BirthDate
 {
     private const FORMAT = 'Y-m-d';
 
-    /** @ORM\Column(name="birth_date", type="date_immutable") */
+    #[Column(name: 'birth_date', type: 'date_immutable')]
     private \DateTimeImmutable $date;
 
     private function __construct(\DateTimeImmutable $date)

--- a/src/Value/Person/Gender.php
+++ b/src/Value/Person/Gender.php
@@ -3,24 +3,23 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Person;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\Person\InvalidGender;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class Gender
 {
     private const MALE = 'M';
     private const FEMALE = 'F';
 
     /**
-     * @ORM\Column(name="gender", length=1)
-     *
      * @var string
      */
+    #[Column(name: 'gender', length: 1)]
     private $gender;
 
     private function __construct(string $gender)

--- a/src/Value/Person/Gender.php
+++ b/src/Value/Person/Gender.php
@@ -7,18 +7,14 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\Person\InvalidGender;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class Gender
 {
     private const MALE = 'M';
     private const FEMALE = 'F';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(name: 'gender', length: 1)]
     private $gender;
 

--- a/src/Value/Person/Name.php
+++ b/src/Value/Person/Name.php
@@ -3,29 +3,27 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Person;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Value\Person\Name\FirstName;
 use MyOnlineStore\Common\Domain\Value\Person\Name\LastName;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class Name
 {
     /**
-     * @ORM\Embedded(class="MyOnlineStore\Common\Domain\Value\Person\Name\FirstName", columnPrefix=false)
-     *
      * @var FirstName
      */
+    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Person\Name\FirstName', columnPrefix: false)]
     private $firstName;
 
     /**
-     * @ORM\Embedded(class="MyOnlineStore\Common\Domain\Value\Person\Name\LastName", columnPrefix=false)
-     *
      * @var LastName
      */
+    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Person\Name\LastName', columnPrefix: false)]
     private $lastName;
 
     public function __construct(FirstName $first, LastName $last)

--- a/src/Value/Person/Name.php
+++ b/src/Value/Person/Name.php
@@ -15,16 +15,12 @@ use MyOnlineStore\Common\Domain\Value\Person\Name\LastName;
 #[Embeddable]
 final class Name
 {
-    /**
-     * @var FirstName
-     */
-    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Person\Name\FirstName', columnPrefix: false)]
+    /** @var FirstName */
+    #[Embedded(class: FirstName::class, columnPrefix: false)]
     private $firstName;
 
-    /**
-     * @var LastName
-     */
-    #[Embedded(class: 'MyOnlineStore\Common\Domain\Value\Person\Name\LastName', columnPrefix: false)]
+    /** @var LastName */
+    #[Embedded(class: LastName::class, columnPrefix: false)]
     private $lastName;
 
     public function __construct(FirstName $first, LastName $last)

--- a/src/Value/Person/Name.php
+++ b/src/Value/Person/Name.php
@@ -5,6 +5,7 @@ namespace MyOnlineStore\Common\Domain\Value\Person;
 
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
+use Doctrine\ORM\Mapping\Embedded;
 use MyOnlineStore\Common\Domain\Value\Person\Name\FirstName;
 use MyOnlineStore\Common\Domain\Value\Person\Name\LastName;
 

--- a/src/Value/Person/Name/FirstName.php
+++ b/src/Value/Person/Name/FirstName.php
@@ -8,15 +8,11 @@ use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class FirstName
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(name: 'first_name')]
     private $firstName;
 

--- a/src/Value/Person/Name/FirstName.php
+++ b/src/Value/Person/Name/FirstName.php
@@ -3,22 +3,21 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Person\Name;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class FirstName
 {
     /**
-     * @ORM\Column(name="first_name")
-     *
      * @var string
      */
+    #[Column(name: 'first_name')]
     private $firstName;
 
     private function __construct(string $firstName)

--- a/src/Value/Person/Name/LastName.php
+++ b/src/Value/Person/Name/LastName.php
@@ -3,22 +3,21 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Person\Name;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\Assert;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class LastName
 {
     /**
-     * @ORM\Column(name="last_name")
-     *
      * @var string
      */
+    #[Column(name: 'last_name')]
     private $lastName;
 
     private function __construct(string $lastName)

--- a/src/Value/RegionCode.php
+++ b/src/Value/RegionCode.php
@@ -15,9 +15,7 @@ use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 #[Embeddable]
 final class RegionCode
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(name: 'region_code', type: 'string', length: 2)]
     private $code;
 

--- a/src/Value/RegionCode.php
+++ b/src/Value/RegionCode.php
@@ -3,23 +3,22 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Exception\InvalidArgument;
 
 /**
  * ISO 3166-1 alpha-2 code (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
  *
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class RegionCode
 {
     /**
-     * @ORM\Column(name="region_code", type="string", length=2)
-     *
      * @var string
      */
+    #[Column(name: 'region_code', type: 'string', length: 2)]
     private $code;
 
     /**

--- a/src/Value/StoreId.php
+++ b/src/Value/StoreId.php
@@ -5,15 +5,11 @@ namespace MyOnlineStore\Common\Domain\Value;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class StoreId
 {
-    /**
-     * @var int|string
-     */
+    /** @var int|string */
     #[Column(name: 'store_id', type: 'integer')]
     private $id;
 

--- a/src/Value/StoreId.php
+++ b/src/Value/StoreId.php
@@ -2,20 +2,19 @@
 
 namespace MyOnlineStore\Common\Domain\Value;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class StoreId
 {
     /**
-     * @ORM\Column(name="store_id", type="integer")
-     *
      * @var int|string
      */
+    #[Column(name: 'store_id', type: 'integer')]
     private $id;
 
     /** @param int|string $id */

--- a/src/Value/Web/IPAddress.php
+++ b/src/Value/Web/IPAddress.php
@@ -6,15 +6,11 @@ namespace MyOnlineStore\Common\Domain\Value\Web;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class IPAddress
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     #[Column(name: 'ip_address', length: 39)]
     private $value;
 

--- a/src/Value/Web/IPAddress.php
+++ b/src/Value/Web/IPAddress.php
@@ -3,20 +3,19 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Web;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class IPAddress
 {
     /**
-     * @ORM\Column(name="ip_address", length=39)
-     *
      * @var string
      */
+    #[Column(name: 'ip_address', length: 39)]
     private $value;
 
     /**

--- a/src/Value/Web/ViewPort.php
+++ b/src/Value/Web/ViewPort.php
@@ -5,11 +5,10 @@ namespace MyOnlineStore\Common\Domain\Value\Web;
 
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
+use Doctrine\ORM\Mapping\Id;
 use MyOnlineStore\Common\Domain\Assertion\EnumValueGuardTrait;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 #[Embeddable]
 final class ViewPort
 {
@@ -19,10 +18,7 @@ final class ViewPort
     const MEDIUM = 'medium';
     const LARGE = 'large';
 
-    /**
-     *
-     * @var string
-     */
+    /** @var string */
     #[Id]
     #[Column(type: 'string', name: 'viewport')]
     private $value;

--- a/src/Value/Web/ViewPort.php
+++ b/src/Value/Web/ViewPort.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Domain\Value\Web;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
 use MyOnlineStore\Common\Domain\Assertion\EnumValueGuardTrait;
 
 /**
- * @ORM\Embeddable
- *
  * @psalm-immutable
  */
+#[Embeddable]
 final class ViewPort
 {
     use EnumValueGuardTrait;
@@ -20,11 +20,11 @@ final class ViewPort
     const LARGE = 'large';
 
     /**
-     * @ORM\Id
-     * @ORM\Column(type="string", name="viewport")
      *
      * @var string
      */
+    #[Id]
+    #[Column(type: 'string', name: 'viewport')]
     private $value;
 
     /**


### PR DESCRIPTION
## Summary 🌟
This changes the deprecated annotation docblocks to attribute. Used rector to change the blocks and then rearranged the comments there were needed manually.

## Technical choices ⚙️

- Introduced `3.x-dev` branch due to Doctrine `3.x` [not being BC](https://github.com/doctrine/orm/blob/3.0.x/UPGRADE.md).
- Used rector's `DoctrineSetList::ANNOTATIONS_TO_ATTRIBUTES` as-per [upgrade guide](https://www.doctrine-project.org/2022/11/04/annotations-to-attributes.html).
- Fixed a phpunit test regarding the currentcy code of Sierra Leone. The unit test relies on a list as provided by `moneyphp/money`. <sup>[[1]](https://en.wikipedia.org/wiki/Category:Currencies_with_ISO_4217_code)</sup>
   - This _was_ SLL and currently _is_ SLE <sup>[[2]](https://en.wikipedia.org/wiki/Sierra_Leonean_leone)</sup> 
   - Added the Bolívar Soberano (VED) from `moneyphp/money`
- Fixed the PHPUnit configuration deprecation: `1) Your XML configuration validates against a deprecated schema. Migrate your XML configuration using "--migrate-configuration"!`

## Testing instructions 📚
You can test this PR by following these steps:

1. You can use `myparcel-shipment-logger` to test this PR as it's currently using the attribute driver through this branch on [this PR](https://github.com/MyOnlineStore/myparcel-shipment-logger/pull/293). Proceed on that project with these testing instructions.
2. Make sure to clear the cache.
3. Make sure you've ran `make composer install`.
4. Run `make analyse` and observe that the StoreId class does not come up.
5. Run an `Myparcel` -> `ShipmentLogger` -> `Shipments` insomnia call (that uses the StoreId).

---

## Manual running test CI
The reason we run these manually is exceptional. This repo does not have access to the runners. I will run these all by hand and post the results here.

**Note:** I will get this fixed on a separate track with csi.

<details>
  <summary>PHPUnit</summary>

   ```
04ff9400b217:/srv/app/vendor/myonlinestore/common-domain$ ./vendor/bin/phpunit --migrate-configuration
PHPUnit 10.5.10 by Sebastian Bergmann and contributors.

Created backup:         /srv/app/vendor/myonlinestore/common-domain/phpunit.xml.dist.bak
Migrated configuration: /srv/app/vendor/myonlinestore/common-domain/phpunit.xml.dist
04ff9400b217:/srv/app/vendor/myonlinestore/common-domain$ ./vendor/bin/phpunit
PHPUnit 10.5.10 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.8
Configuration: /srv/app/vendor/myonlinestore/common-domain/phpunit.xml.dist

...............................................................  63 / 355 ( 17%)
............................................................... 126 / 355 ( 35%)
............................................................... 189 / 355 ( 53%)
............................................................... 252 / 355 ( 70%)
............................................................... 315 / 355 ( 88%)
........................................                        355 / 355 (100%)

Time: 00:00.107, Memory: 16.00 MB

OK (355 tests, 959 assertions)
   ```
</details>

<details>
  <summary>Psalm</summary>

   ```
[rob@SoaringDragon configuration]$ make attach php
04ff9400b217:/srv/app# ./vendor/bin/psalm
Target PHP version: 8.2 (inferred from current PHP version).
Scanning files...
Analyzing files...

░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  60 / 165 (36%)
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 120 / 165 (72%)
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

------------------------------
                              
       No errors found!       
                              
------------------------------
60 other issues found.
You can display them with --show-info=true
------------------------------

Checks took 7.81 seconds and used 259.238MB of memory
Psalm was able to infer types for 97.3822% of the codebase
   ```
</details>
