### PR TITLE
chore(MOS-2147): Updated github action to use ubuntu latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     test:
         name: Test
 
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
 
         steps:
             # Setup

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "myonlinestore/coding-standard": "^3.1",
-        "phpbench/phpbench": "dev-master",
+        "phpbench/phpbench": "1.2.14",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.15",
         "roave/infection-static-analysis-plugin": "^1.7",

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,10 @@
         "vimeo/psalm": "^4.7"
     },
     "config": {
+        "allow-plugins": {
+            "infection/extension-installer": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
         "sort-packages": true,
         "platform": {
             "php": "8.0.3"


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci.yml` file. The change updates the runner version for the test job to use the latest Ubuntu version.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL14-R14): Changed the `runs-on` parameter from `ubuntu-20.04` to `ubuntu-latest` for the test job.